### PR TITLE
Fix jitter buffer pool

### DIFF
--- a/OpenFreq.Client/Program.cs
+++ b/OpenFreq.Client/Program.cs
@@ -28,6 +28,19 @@ sealed class Program
             .MinimumLevel.Debug()
             .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
             .MinimumLevel.Override("System", LogEventLevel.Warning)
+            
+            
+            // OVERRIDES - Disables Debug Logs
+            // --------------------------------
+            // Outputs the Playback Buffer State
+            .MinimumLevel.Override("OpenFreqAudio.RadioPlayback", LogEventLevel.Warning)
+            
+            // Outputs the Physics Calculations
+            .MinimumLevel.Override("OpenFreqAudio.FastPathAudioSim", LogEventLevel.Warning)
+            
+            // Outputs the packet timings (playback queue)
+            .MinimumLevel.Override("OpenFreq.Common.RtpAudioReceiver", LogEventLevel.Warning)
+            
             .Enrich.FromLogContext()
             .Enrich.WithProperty("Application", "OpenFreqClient")
             .WriteTo.File(
@@ -36,7 +49,7 @@ sealed class Program
                 rollingInterval: RollingInterval.Day,
                 retainedFileCountLimit: 30,
                 shared: true)
-            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}")
+            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss.fff} {Level:u3}] [{SourceContext}] {Message:lj}{NewLine}{Exception}")
             .CreateLogger();
 #else
         Log.Logger = new LoggerConfiguration()

--- a/OpenFreq.Client/Services/OpenFreqService.cs
+++ b/OpenFreq.Client/Services/OpenFreqService.cs
@@ -817,13 +817,13 @@ public class OpenFreqService : IOpenFreqService
     {
         if (e.AudioData.Length == 0)
         {
-            _logger.LogWarning($"Audio data received with 0 size");
+            _logger.LogWarning("Audio data received with 0 size");
             return;
         }
 
         if (e.Metadata.Frequencies.Count == 0)
         {
-            _logger.LogWarning($"Audio data received without frequencies, dropping");
+            _logger.LogWarning("Audio data received without frequencies, dropping");
             return;
         }
 

--- a/OpenFreq.Client/Services/OpenFreqService.cs
+++ b/OpenFreq.Client/Services/OpenFreqService.cs
@@ -712,6 +712,11 @@ public class OpenFreqService : IOpenFreqService
             _ => Status
         };
 
+        if (e.State == ConnectionState.Disconnected)
+        {
+            _tunedFrequencies.Clear();
+        }
+
         ConnectionStateChanged?.Invoke(this, e.State);
     }
 

--- a/OpenFreq.Common/OpenFreqRtcClient.cs
+++ b/OpenFreq.Common/OpenFreqRtcClient.cs
@@ -138,6 +138,7 @@ public class OpenFreqRtcClient : IDisposable
         catch (Exception ex)
         {
             _isConnected = false;
+            _isAuthenticated = false;
             OnConnectionStateChanged(ConnectionState.Disconnected);
             OnError($"Connection failed: {ex.Message}");
             throw;
@@ -335,6 +336,7 @@ public class OpenFreqRtcClient : IDisposable
                     await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Server closing",
                         CancellationToken.None);
                     _isConnected = false;
+                    _isAuthenticated = false;
                     OnConnectionStateChanged(ConnectionState.Disconnected);
                     break;
                 }
@@ -360,6 +362,7 @@ public class OpenFreqRtcClient : IDisposable
         {
             OnError($"WebSocket error: {ex.Message}");
             _isConnected = false;
+            _isAuthenticated = false;
             OnConnectionStateChanged(ConnectionState.Disconnected);
         }
     }

--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -42,7 +42,7 @@ public class RtpAudioReceiver : IDisposable
     private int _pruneCountdown = 50;
 
     private const int OPUS_FRAME_SAMPLES = 960; // 20ms at 48kHz (matches sender)
-    private const int PLAYOUT_INTERVAL_MS = 20;
+    public static int PLAYOUT_INTERVAL_MS = 20;
 
     public RtpAudioReceiver(ILoggerFactory loggerFactory, UdpClient udpClient, bool opusEnabled = true,
         int initialBufferMs = 150)

--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -6,11 +6,14 @@ using Concentus.Structs;
 using Microsoft.Extensions.Logging;
 using OpenFreq.Common.Rtp;
 
+// This is to avoid issues in Linux where the Concentus Factory methods does not work currently.
+#pragma warning disable CS0618 // Type or member is obsolete
+
 namespace OpenFreq.Common;
 
 /// <summary>
-/// RTP audio receiver with adaptive jitter buffering.
-/// Handles network layer: RTP parsing, jitter buffer, packet reordering, Opus decoding.
+/// RTP audio receiver with per-SSRC adaptive jitter buffering. Each concurrent talker (SSRC) gets an
+/// independent jitter buffer and Opus decoder so their state never interferes.
 /// Outputs clean, ordered PCM audio ready for RadioPlayback.
 /// </summary>
 public class RtpAudioReceiver : IDisposable
@@ -26,93 +29,64 @@ public class RtpAudioReceiver : IDisposable
 
     private readonly ILogger<RtpAudioReceiver> _logger;
     private readonly UdpClient _udpClient;
-    private readonly RtpJitterBuffer _jitterBuffer;
-    private readonly OpusDecoder? _opusDecoder;
+    private readonly RtpJitterBufferPool _pool;
     private readonly bool _opusEnabled;
     private readonly CancellationTokenSource _cts = new();
     private readonly Timer _playoutTimer;
-    private readonly ILoggerFactory _loggerFactory;
-    
-    // Track expected sequence for loss detection
-    private ushort _lastSequenceReceived;
-    private bool _firstPacketReceived;
-    
-    // Track last valid metadata for PLC frequency reconstruction
-    private AudioPacketMetadata? _lastValidMetadata = null;
-    
-    // FEC statistics
-    private int _fecRecoveries = 0;
-    private int _plcRecoveries = 0;
-    
-    // Frame size must be exact for PLC/FEC to maintain proper decoder state
-    // Per Concentus docs: "frame_size needs to be exactly the duration of the audio that is missing,
-    // otherwise the decoder will not be in an optimal state to decode the next incoming packet"
+
+    // FEC statistics (aggregate across all sources)
+    private int _fecRecoveries;
+    private int _plcRecoveries;
+
+    // Prune stale sources every N ticks (20ms * 50 = 1s)
+    private int _pruneCountdown = 50;
+
     private const int OPUS_FRAME_SAMPLES = 960; // 20ms at 48kHz (matches sender)
-    private const int PLAYOUT_INTERVAL_MS = 20; // Check for ready packets every 20ms
-        
-    /// <summary>
-    /// Create RTP audio receiver with adaptive jitter buffer
-    /// </summary>
-    /// <param name="logger">Logger instance</param>
-    /// <param name="udpClient">Existing UDP client</param>
-    /// <param name="opusEnabled">Whether to decode Opus (true) or expect raw PCM (false)</param>
-    /// <param name="initialBufferMs">Initial jitter buffer size in milliseconds (will adapt)</param>
-    public RtpAudioReceiver(ILoggerFactory loggerFactory, UdpClient udpClient, bool opusEnabled = true, int initialBufferMs = 150)
+    private const int PLAYOUT_INTERVAL_MS = 20;
+
+    public RtpAudioReceiver(ILoggerFactory loggerFactory, UdpClient udpClient, bool opusEnabled = true,
+        int initialBufferMs = 150)
     {
-        _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<RtpAudioReceiver>();
         _opusEnabled = opusEnabled;
 
-        if (_opusEnabled)
-        {
-            #pragma warning disable CS0618 // Using the new factory method will not work in Linux!
-            _opusDecoder =  new OpusDecoder(OpenFreqRtcClient.SAMPLE_RATE, OpenFreqRtcClient.CHANNELS) as OpusDecoder;
-            #pragma warning restore CS0618 // Type or member is obsolete
-        }
+        _pool = new RtpJitterBufferPool(loggerFactory, opusEnabled, initialBufferMs);
+        _pool.SourceAdded += ssrc => _logger.LogInformation("Source joined:  SSRC={Ssrc:X8}", ssrc);
+        _pool.SourceExpired += ssrc => _logger.LogInformation("Source expired: SSRC={Ssrc:X8}", ssrc);
 
-        // Create jitter buffer
-        _jitterBuffer = new RtpJitterBuffer(loggerFactory.CreateLogger<RtpJitterBuffer>());
-        _jitterBuffer.SetTargetBufferSize(initialBufferMs);
-
-        // Reuse UDP Client
         _udpClient = udpClient;
         var port = (_udpClient.Client.LocalEndPoint as IPEndPoint)!.Port;
         _logger.LogInformation("Started on port {Port}", port);
         _logger.LogInformation("  Opus: {OpusEnabled}", _opusEnabled);
-        _logger.LogInformation("  Initial buffer: {BufferMs}ms (adaptive)", initialBufferMs);
+        _logger.LogInformation("  Initial buffer: {BufferMs}ms (adaptive, per-SSRC)", initialBufferMs);
 
-        // Start receiving task
         Task.Run(() => ReceiveLoop(), _cts.Token);
-            
-        // Start playout timer (pulls packets from jitter buffer)
         _playoutTimer = new Timer(PlayoutTimerCallback, null, 0, PLAYOUT_INTERVAL_MS);
 
         if (!_logger.IsEnabled(LogLevel.Debug))
         {
-            Task.Run(() =>
-            {
-                while (true)
+            Task.Run(async () =>
                 {
-                    var stats = GetStatistics();
-                    _logger.LogDebug("Network Stats");
-                    _logger.LogDebug("  Packets: received={Received}, lost={Lost} ({LossPercent:F1}%)",
-                        stats.received, stats.lost, stats.lossPercent);
-                    _logger.LogDebug("  Jitter: {JitterMs:F1}ms", stats.jitterMs);
-                    _logger.LogDebug("  Buffer size: {BufferMs:F0}ms (adaptive)", stats.bufferMs);
-                    _logger.LogDebug("  Buffered packets: {Buffered}", stats.buffered);
-                    Task.Delay(5000).Wait();
+                    while (true)
+                    {
+                        var stats = GetStatistics();
+                        _logger.LogDebug("Network Stats (aggregated)");
+                        _logger.LogDebug("  Packets: received={Received}, lost={Lost} ({LossPercent:F1}%)",
+                            stats.received, stats.lost, stats.lossPercent);
+                        _logger.LogDebug("  Jitter: {JitterMs:F1}ms (avg across sources)", stats.jitterMs);
+                        _logger.LogDebug("  Buffer size: {BufferMs:F0}ms (avg, adaptive)", stats.bufferMs);
+                        _logger.LogDebug("  Buffered packets: {Buffered}", stats.buffered);
+                        await Task.Delay(5000);
+                    }
                 }
-            });
+            );
         }
     }
 
-    /// <summary>
-    /// UDP receive loop - receives packets and adds to jitter buffer
-    /// </summary>
     private async Task ReceiveLoop()
     {
         _logger.LogInformation("Receive loop started");
-            
+
         while (!_cts.Token.IsCancellationRequested)
         {
             try
@@ -122,25 +96,21 @@ public class RtpAudioReceiver : IDisposable
             }
             catch (OperationCanceledException)
             {
-                break; // Expected during shutdown
+                break;
             }
             catch (Exception ex)
             {
                 ErrorOccurred?.Invoke(this, $"Receive error: {ex.Message}");
             }
         }
-            
+
         _logger.LogInformation("Receive loop stopped");
     }
 
-    /// <summary>
-    /// Process incoming UDP packet
-    /// </summary>
     private void ProcessIncomingPacket(byte[] data)
     {
         try
         {
-            // Parse RTP packet
             var rtpPacket = RtpPacket.Parse(data);
             if (rtpPacket == null)
             {
@@ -148,8 +118,8 @@ public class RtpAudioReceiver : IDisposable
                 return;
             }
 
-            // Add to jitter buffer (handles reordering, timing)
-            _jitterBuffer.AddPacket(rtpPacket);
+            // Pool demuxes by SSRC automatically
+            _pool.AddPacket(rtpPacket);
         }
         catch (Exception ex)
         {
@@ -158,59 +128,59 @@ public class RtpAudioReceiver : IDisposable
     }
 
     /// <summary>
-    /// Playout timer callback - pulls ready packets from jitter buffer
-    /// Rate-limited: processes one packet per 20ms tick to prevent bursts
+    /// Playout timer callback. Polls every active SSRC for a ready packet,
+    /// performing per-source FEC/PLC concealment independently.
     /// </summary>
     private void PlayoutTimerCallback(object? state)
     {
         try
         {
-            // Pull one ready packet per timer tick (prevents bursts that cause underruns)
-            if (_jitterBuffer.GetNextPacket() is { } packet)
+            // Prune sources that have gone silent
+            if (--_pruneCountdown <= 0)
             {
-                // Detect lost packets and generate concealment audio (FEC or PLC)
-                if (_firstPacketReceived)
+                _pool.PruneStale();
+                _pruneCountdown = 50;
+            }
+
+            foreach (var context in _pool.GetActiveSources())
+            {
+                // One packet per SSRC per 20ms tick — burst delivery is handled
+                // by AdjustPlayoutClock advancing the playout clock incrementally.
+                if (context.JitterBuffer.GetNextPacket() is { } packet)
                 {
-                    ushort expectedSeq = (ushort)(_lastSequenceReceived + 1);
-                    
-                    // Check for gap in sequence numbers
-                    if (packet.SequenceNumber != expectedSeq)
+
+                    // Loss detection and concealment — per-source sequence
+                    if (context.FirstPacketReceived)
                     {
-                        int gap = RtpPacket.SequenceDifference(packet.SequenceNumber, expectedSeq);
-                        
-                        if (gap > 0 && gap < 100) // Sanity check - only handle reasonable gaps
+                        ushort expectedSeq = (ushort)(context.LastSequenceReceived + 1);
+
+                        if (packet.SequenceNumber != expectedSeq)
                         {
-                            _logger.LogDebug("Detected {Gap} lost packets (seq {Start} to {End}), generating concealment", 
-                                gap, expectedSeq, packet.SequenceNumber - 1);
-                            
-                            // Generate concealment for each lost packet
-                            // The first lost packet can use FEC from current packet
-                            // Subsequent lost packets must use PLC (we only have one "next" packet)
-                            for (int i = 0; i < gap; i++)
+                            int gap = RtpPacket.SequenceDifference(packet.SequenceNumber, expectedSeq);
+
+                            if (gap > 0 && gap < 100)
                             {
-                                ushort lostSeq = (ushort)(expectedSeq + i);
-                                
-                                // Only the first lost packet gets FEC attempt (using current packet)
-                                // This is because current packet contains FEC for the previous (first lost) packet
-                                if (i == 0)
+                                _logger.LogDebug(
+                                    "SSRC={Ssrc:X8}: {Gap} lost packet(s) (seq {Start} to {End}), generating concealment",
+                                    context.Ssrc, gap, expectedSeq, packet.SequenceNumber - 1);
+
+                                for (int i = 0; i < gap; i++)
                                 {
-                                    GenerateConcealmentAudio(lostSeq, packet);  // Pass current packet for FEC
-                                }
-                                else
-                                {
-                                    GenerateConcealmentAudio(lostSeq, null);    // Subsequent: PLC only
+                                    ushort lostSeq = (ushort)(expectedSeq + i);
+                                    // Only the first lost packet can use FEC (next packet carries FEC for it)
+                                    GenerateConcealmentAudio(lostSeq, i == 0 ? packet : null, context);
                                 }
                             }
                         }
                     }
+                    else
+                    {
+                        context.FirstPacketReceived = true;
+                    }
+
+                    context.LastSequenceReceived = packet.SequenceNumber;
+                    ProcessReadyPacket(packet, context);
                 }
-                else
-                {
-                    _firstPacketReceived = true;
-                }
-                
-                _lastSequenceReceived = packet.SequenceNumber;
-                ProcessReadyPacket(packet);
             }
         }
         catch (Exception ex)
@@ -218,121 +188,17 @@ public class RtpAudioReceiver : IDisposable
             ErrorOccurred?.Invoke(this, $"Playout error: {ex.Message}");
         }
     }
-    
-    /// <summary>
-    /// Generate concealment audio for a lost packet (FEC preferred, PLC fallback)
-    /// </summary>
-    /// <param name="lostSequence">Sequence number of the lost packet</param>
-    /// <param name="nextPacket">The packet AFTER the lost one (contains FEC data for lost packet)</param>
-    private void GenerateConcealmentAudio(ushort lostSequence, RtpPacket? nextPacket)
-    {
-        if (!_opusEnabled || _opusDecoder == null)
-            return;
-            
-        try
-        {
-            byte[] concealmentAudio;
-            bool usedFec = false;
-            
-            // Try FEC if we have the next packet
-            // According to Concentus docs: "you will actually decode this packet twice, first with decode_fec TRUE and then again with FALSE"
-            if (nextPacket != null)
-            {
-                var nextPacketOpusData = ExtractOpusDataFromPacket(nextPacket);
-                
-                _logger.LogDebug("Loss recovery for seq {LostSeq}: have nextPacket (seq {NextSeq}), OpusData={Bytes} bytes", 
-                    lostSequence, nextPacket.SequenceNumber, nextPacketOpusData?.Length ?? 0);
-                
-                if (nextPacketOpusData != null && nextPacketOpusData.Length > 0)
-                {
-                    // Decode with decode_fec=TRUE to extract FEC data for the LOST packet
-                    // The nextPacket will be decoded AGAIN with decode_fec=FALSE in ProcessReadyPacket()
-                    concealmentAudio = DecodeOpus(nextPacketOpusData, isLost: false, decodeFec: true);
-                    
-                    if (concealmentAudio.Length > 0)
-                    {
-                        usedFec = true;
-                        _fecRecoveries++;
-                        _logger.LogInformation("✓ FEC: Recovered seq {LostSeq} using FEC from seq {NextSeq} ({Bytes} bytes)", 
-                            lostSequence, nextPacket.SequenceNumber, concealmentAudio.Length);
-                    }
-                    else
-                    {
-                        // FEC decode failed (no FEC data in packet, or decode error)
-                        _logger.LogDebug("  FEC decode returned 0 bytes, falling back to PLC");
-                        concealmentAudio = DecodeOpus([], isLost: true);
-                        _plcRecoveries++;
-                    }
-                }
-                else
-                {
-                    // Couldn't extract Opus data
-                    _logger.LogDebug("  Could not extract Opus data, using PLC");
-                    concealmentAudio = DecodeOpus([], isLost: true);
-                    _plcRecoveries++;
-                }
-            }
-            else
-            {
-                // No next packet available - use PLC
-                _logger.LogDebug("Loss recovery for seq {LostSeq}: no nextPacket, using PLC", lostSequence);
-                concealmentAudio = DecodeOpus([], isLost: true);
-                _plcRecoveries++;
-            }
-            
-            if (concealmentAudio.Length > 0)
-            {
-                // Reconstruct frequency list from last valid packet
-                var frequencies = new List<FrequencyTransmission>();
-                
-                if (_lastValidMetadata?.Frequencies != null)
-                {
-                    foreach (var freq in _lastValidMetadata.Frequencies)
-                    {
-                        frequencies.Add(new FrequencyTransmission(
-                            khz: freq.Khz,
-                            txPowerWatts: freq.TxPowerWatts,
-                            ppm: freq.Ppm,
-                            position: freq.Position,
-                            velocity: freq.Velocity,
-                            in3d: freq.In3d,
-                            ambientNoiseType: freq.AmbientNoiseType,
-                            beginMarker: false,
-                            endMarker: false
-                        ));
-                    }
-                }
-                
-                var metadata = new AudioPacketMetadata
-                {
-                    ClientId = _lastValidMetadata?.ClientId ?? (usedFec ? "FEC" : "PLC"),
-                    Frequencies = frequencies
-                };
-                
-                AudioReceived?.Invoke(this, new AudioReceivedEventArgs
-                {
-                    AudioData = concealmentAudio,
-                    Metadata = metadata
-                });
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to generate concealment audio for seq {LostSeq}", lostSequence);
-        }
-    }
 
     /// <summary>
-    /// Process packet that's ready for playout
+    /// Process a packet that is ready for playout, using the source's own Opus decoder.
     /// </summary>
-    private void ProcessReadyPacket(RtpPacket packet)
+    private void ProcessReadyPacket(RtpPacket packet, RtpSourceContext context)
     {
         try
         {
-            // Parse metadata from RTP header extension
             if (packet.ExtensionData is not { Length: > 0 })
             {
-                _logger.LogWarning("Missing RTP header extension metadata");
+                _logger.LogWarning("SSRC={Ssrc:X8}: missing RTP header extension metadata", context.Ssrc);
                 return;
             }
 
@@ -341,31 +207,28 @@ public class RtpAudioReceiver : IDisposable
 
             if (metadata == null)
             {
-                _logger.LogWarning("Failed to parse metadata");
+                _logger.LogWarning("SSRC={Ssrc:X8}: failed to parse metadata", context.Ssrc);
                 return;
             }
 
-            // Save metadata for PLC frequency reconstruction
-            _lastValidMetadata = metadata;
+            context.LastValidMetadata = metadata;
 
-            // Payload is pure audio data
-            var audioData = packet.Payload;
-
-            // Decode audio if Opus is enabled
             byte[] decodedAudio;
-            if (_opusEnabled && _opusDecoder != null)
+            if (_opusEnabled && context.OpusDecoder != null)
             {
-                decodedAudio = DecodeOpus(audioData, isLost: false, decodeFec: false);
+                decodedAudio = DecodeOpus(packet.Payload, context.OpusDecoder, isLost: false, decodeFec: false);
                 if (decodedAudio.Length == 0)
-                    return; // Decode failed
+                    return;
             }
             else
             {
-                // Raw PCM - use as-is
-                decodedAudio = audioData;
+                decodedAudio = packet.Payload;
             }
 
-            // Fire event with clean audio
+            #if DEBUG
+            _logger.LogDebug($"Playing packet from {packet.Ssrc}: {packet.SequenceNumber}");
+            #endif
+            
             AudioReceived?.Invoke(this, new AudioReceivedEventArgs
             {
                 AudioData = decodedAudio,
@@ -379,85 +242,149 @@ public class RtpAudioReceiver : IDisposable
     }
 
     /// <summary>
-    /// Decode Opus audio with PLC support
+    /// Generate FEC or PLC concealment audio for a lost packet within one source's context.
     /// </summary>
-    /// <param name="opusData">Opus-encoded data, or empty array for PLC</param>
-    /// <param name="isLost">True if this is a lost packet requiring PLC</param>
-    /// <param name="decodeFec">True to decode FEC data from this packet (for previous lost packet)</param>
-    private byte[] DecodeOpus(byte[] opusData, bool isLost = false, bool decodeFec = false)
+    private void GenerateConcealmentAudio(ushort lostSequence, RtpPacket? nextPacket, RtpSourceContext context)
     {
-        if (_opusDecoder == null)
-            return [];
+        if (!_opusEnabled || context.OpusDecoder == null)
+            return;
 
         try
         {
-            const int MAX_OPUS_FRAME_SAMPLES = 5760; // 120ms at 48kHz
-            short[] pcmSamples = new short[MAX_OPUS_FRAME_SAMPLES];
+            byte[] concealmentAudio;
+            bool usedFec = false;
 
-            int? samplesDecoded;
-            
-            if (isLost)
+            if (nextPacket != null)
             {
-                // Use Opus PLC for lost packets
-                samplesDecoded = _opusDecoder?.Decode(
-                    Array.Empty<byte>(),  // Empty array triggers PLC
-                    0, 
-                    0, 
-                    pcmSamples, 
-                    0, 
-                    OPUS_FRAME_SAMPLES,  // Must match exact frame duration for proper decoder state
-                    false
-                );
-                
-                if (samplesDecoded > 0)
+                var nextOpusData = ExtractOpusDataFromPacket(nextPacket);
+
+                _logger.LogDebug(
+                    "SSRC={Ssrc:X8}: loss recovery for seq {LostSeq}: nextPacket seq {NextSeq}, {Bytes} bytes",
+                    context.Ssrc, lostSequence, nextPacket.SequenceNumber, nextOpusData?.Length ?? 0);
+
+                if (nextOpusData is { Length: > 0 })
                 {
-                    _logger.LogDebug("Generated PLC audio: {Samples} samples", samplesDecoded);
+                    concealmentAudio = DecodeOpus(nextOpusData, context.OpusDecoder, isLost: false, decodeFec: true);
+
+                    if (concealmentAudio.Length > 0)
+                    {
+                        usedFec = true;
+                        Interlocked.Increment(ref _fecRecoveries);
+                        _logger.LogInformation(
+                            "SSRC={Ssrc:X8}: ✓ FEC recovered seq {LostSeq} from seq {NextSeq} ({Bytes} bytes)",
+                            context.Ssrc, lostSequence, nextPacket.SequenceNumber, concealmentAudio.Length);
+                    }
+                    else
+                    {
+                        _logger.LogDebug("SSRC={Ssrc:X8}: FEC returned 0 bytes, falling back to PLC", context.Ssrc);
+                        concealmentAudio = DecodeOpus([], context.OpusDecoder, isLost: true);
+                        Interlocked.Increment(ref _plcRecoveries);
+                    }
                 }
-            }
-            else if (decodeFec)
-            {
-                // Decode FEC data from this packet
-                samplesDecoded = _opusDecoder?.Decode(
-                    opusData, 
-                    0, 
-                    opusData.Length, 
-                    pcmSamples, 
-                    0, 
-                    OPUS_FRAME_SAMPLES,
-                    true 
-                );
-                
-                if (samplesDecoded > 0)
+                else
                 {
-                    _logger.LogDebug("FEC decode successful: {Samples} samples from {Bytes} bytes", 
-                        samplesDecoded, opusData.Length);
+                    _logger.LogDebug("SSRC={Ssrc:X8}: could not extract Opus data, using PLC", context.Ssrc);
+                    concealmentAudio = DecodeOpus([], context.OpusDecoder, isLost: true);
+                    Interlocked.Increment(ref _plcRecoveries);
                 }
             }
             else
             {
-                // Normal decode
-                samplesDecoded = _opusDecoder?.Decode(
-                    opusData, 
-                    0, 
-                    opusData.Length, 
-                    pcmSamples, 
-                    0, 
-                    MAX_OPUS_FRAME_SAMPLES, 
-                    false
-                );
+                _logger.LogDebug("SSRC={Ssrc:X8}: no nextPacket for seq {LostSeq}, using PLC", context.Ssrc,
+                    lostSequence);
+                concealmentAudio = DecodeOpus([], context.OpusDecoder, isLost: true);
+                Interlocked.Increment(ref _plcRecoveries);
+            }
+
+            if (concealmentAudio.Length == 0)
+                return;
+
+            var frequencies = new List<FrequencyTransmission>();
+            if (context.LastValidMetadata?.Frequencies != null)
+            {
+                foreach (var freq in context.LastValidMetadata.Frequencies)
+                {
+                    frequencies.Add(new FrequencyTransmission(
+                        khz: freq.Khz,
+                        txPowerWatts: freq.TxPowerWatts,
+                        ppm: freq.Ppm,
+                        position: freq.Position,
+                        velocity: freq.Velocity,
+                        in3d: freq.In3d,
+                        ambientNoiseType: freq.AmbientNoiseType,
+                        beginMarker: false,
+                        endMarker: false
+                    ));
+                }
+            }
+
+            var metadata = new AudioPacketMetadata
+            {
+                ClientId = context.LastValidMetadata?.ClientId ?? (usedFec ? "FEC" : "PLC"),
+                Frequencies = frequencies
+            };
+
+            AudioReceived?.Invoke(this, new AudioReceivedEventArgs
+            {
+                AudioData = concealmentAudio,
+                Metadata = metadata
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "SSRC={Ssrc:X8}: failed to generate concealment for seq {LostSeq}",
+                context.Ssrc, lostSequence);
+        }
+    }
+
+    /// <summary>
+    /// Decode Opus audio using the provided decoder instance (one per SSRC).
+    /// </summary>
+    private byte[] DecodeOpus(byte[] opusData, OpusDecoder decoder, bool isLost = false, bool decodeFec = false)
+    {
+        try
+        {
+            const int maxOpusFrameSamples = 5760; // 120ms at 48kHz
+            short[] pcmSamples = new short[maxOpusFrameSamples];
+
+            int? samplesDecoded;
+
+            if (isLost)
+            {
+                samplesDecoded = decoder.Decode(
+                    Array.Empty<byte>(), 0, 0,
+                    pcmSamples, 0, OPUS_FRAME_SAMPLES);
+
+                if (samplesDecoded > 0)
+                    _logger.LogDebug("Generated PLC audio: {Samples} samples", samplesDecoded);
+            }
+            else if (decodeFec)
+            {
+                samplesDecoded = decoder.Decode(
+                    opusData, 0, opusData.Length,
+                    pcmSamples, 0, OPUS_FRAME_SAMPLES,
+                    true);
+
+                if (samplesDecoded > 0)
+                    _logger.LogDebug("FEC decode: {Samples} samples from {Bytes} bytes", samplesDecoded,
+                        opusData.Length);
+            }
+            else
+            {
+                samplesDecoded = decoder.Decode(
+                    opusData, 0, opusData.Length,
+                    pcmSamples, 0, maxOpusFrameSamples);
             }
 
             if (samplesDecoded is null or <= 0)
             {
-                _logger.LogWarning("Opus decode failed for {ByteCount} bytes (isLost={IsLost}, decodeFec={DecodeFec})", 
+                _logger.LogWarning("Opus decode failed for {ByteCount} bytes (isLost={IsLost}, decodeFec={DecodeFec})",
                     opusData.Length, isLost, decodeFec);
                 return [];
             }
 
-            // Convert to byte array (16-bit PCM)
             var decodedAudio = new byte[samplesDecoded.Value * 2];
             Buffer.BlockCopy(pcmSamples, 0, decodedAudio, 0, decodedAudio.Length);
-                
             return decodedAudio;
         }
         catch (Exception ex)
@@ -466,27 +393,14 @@ public class RtpAudioReceiver : IDisposable
             return [];
         }
     }
-    
-    /// <summary>
-    /// Extract Opus-encoded audio data from RTP packet payload
-    /// </summary>
+
     private static byte[]? ExtractOpusDataFromPacket(RtpPacket packet)
-    {
-        return packet.Payload.Length > 0 ? packet.Payload : null;
-    }
+        => packet.Payload.Length > 0 ? packet.Payload : null;
 
-    /// <summary>
-    /// Get receiver statistics
-    /// </summary>
-    public (int received, int lost, int late, int duplicate, int played, 
+    public (int received, int lost, int late, int duplicate, int played,
         double lossPercent, double jitterMs, double bufferMs, int buffered) GetStatistics()
-    {
-        return _jitterBuffer.GetStatistics();
-    }
+        => _pool.GetStatistics();
 
-    /// <summary>
-    /// Print detailed statistics
-    /// </summary>
     public void PrintStatistics()
     {
         var stats = GetStatistics();
@@ -499,33 +413,36 @@ public class RtpAudioReceiver : IDisposable
         _logger.LogInformation("  Loss Recovery:");
         _logger.LogInformation("    FEC recoveries: {FecCount}", _fecRecoveries);
         _logger.LogInformation("    PLC recoveries: {PlcCount}", _plcRecoveries);
-        
+
         if (_fecRecoveries + _plcRecoveries > 0)
         {
             var fecPercent = 100.0 * _fecRecoveries / (_fecRecoveries + _plcRecoveries);
             _logger.LogInformation("    FEC success rate: {FecRate:F1}%", fecPercent);
         }
-        
-        _logger.LogInformation("  Measured jitter: {JitterMs:F1}ms", stats.jitterMs);
-        _logger.LogInformation("  Buffer size: {BufferMs:F0}ms (adaptive)", stats.bufferMs);
+
+        _logger.LogInformation("  Measured jitter: {JitterMs:F1}ms (avg)", stats.jitterMs);
+        _logger.LogInformation("  Buffer size: {BufferMs:F0}ms (avg, adaptive)", stats.bufferMs);
         _logger.LogInformation("  Currently buffered: {Buffered} packets", stats.buffered);
+
+        foreach (var s in _pool.GetPerSourceStatistics())
+        {
+            _logger.LogInformation(
+                "  SSRC={Ssrc:X8}: rx={Rx} lost={Lost} ({Loss:F1}%) jitter={Jitter:F1}ms buffer={Buffer:F0}ms buffered={Buffered}",
+                s.ssrc, s.received, s.lost, s.lossPercent, s.jitterMs, s.bufferMs, s.buffered);
+        }
+
         _logger.LogInformation("================================");
     }
 
-    /// <summary>
-    /// Set jitter buffer size manually (overrides adaptation temporarily)
-    /// </summary>
     public void SetJitterBufferSize(int milliseconds)
-    {
-        _jitterBuffer.SetTargetBufferSize(milliseconds);
-    }
+        => _pool.SetAllBufferSizes(milliseconds);
 
     public void Dispose()
     {
         _cts.Cancel();
-        _playoutTimer?.Dispose();
-        _opusDecoder?.Dispose();
+        _playoutTimer.Dispose();
         PrintStatistics();
+        _pool.Dispose();
         _logger.LogInformation("Disposed");
     }
 }

--- a/OpenFreq.Common/RTPJitterBufferPool.cs
+++ b/OpenFreq.Common/RTPJitterBufferPool.cs
@@ -20,7 +20,7 @@ public sealed class RtpJitterBufferPool : IDisposable
     /// <summary>
     /// How long a source must be silent before it is pruned from the pool.
     /// </summary>
-    public int SourceTimeoutMs { get; set; } = 5_000;
+    public int SourceTimeoutMs { get; set; } = 5 * 60_000;
 
     /// <summary>Fired when a new SSRC is seen for the first time.</summary>
     public event Action<uint>? SourceAdded;

--- a/OpenFreq.Common/RTPJitterBufferPool.cs
+++ b/OpenFreq.Common/RTPJitterBufferPool.cs
@@ -1,0 +1,153 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using OpenFreq.Common.Rtp;
+
+namespace OpenFreq.Common;
+
+/// <summary>
+/// Manages a pool of per-SSRC jitter buffers. Stale sources are pruned automatically.
+/// </summary>
+public sealed class RtpJitterBufferPool : IDisposable
+{
+    private readonly ILogger<RtpJitterBufferPool> _logger;
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly bool _opusEnabled;
+    private readonly int _initialBufferMs;
+
+    private readonly ConcurrentDictionary<uint, RtpSourceContext> _sources = new();
+
+    /// <summary>
+    /// How long a source must be silent before it is pruned from the pool.
+    /// </summary>
+    public int SourceTimeoutMs { get; set; } = 5_000;
+
+    /// <summary>Fired when a new SSRC is seen for the first time.</summary>
+    public event Action<uint>? SourceAdded;
+
+    /// <summary>Fired just before a stale source is removed.</summary>
+    public event Action<uint>? SourceExpired;
+
+    public RtpJitterBufferPool(ILoggerFactory loggerFactory, bool opusEnabled, int initialBufferMs)
+    {
+        _loggerFactory = loggerFactory;
+        _logger = loggerFactory.CreateLogger<RtpJitterBufferPool>();
+        _opusEnabled = opusEnabled;
+        _initialBufferMs = initialBufferMs;
+    }
+
+    /// <summary>
+    /// Route an incoming packet to the correct per-SSRC context,
+    /// creating one if this is the first packet from that source.
+    /// </summary>
+    public void AddPacket(RtpPacket packet)
+    {
+        var context = _sources.GetOrAdd(packet.Ssrc, ssrc =>
+        {
+            _logger.LogInformation("New RTP source: SSRC={Ssrc:X8}", ssrc);
+            var ctx = new RtpSourceContext(ssrc, _loggerFactory, _opusEnabled, _initialBufferMs);
+            SourceAdded?.Invoke(ssrc);
+            return ctx;
+        });
+
+        context.LastActivityTicks = Stopwatch.GetTimestamp();
+        context.JitterBuffer.AddPacket(packet);
+    }
+
+    /// <summary>
+    /// Returns a point-in-time snapshot of all currently active source contexts.
+    /// Safe to iterate while new packets arrive concurrently.
+    /// </summary>
+    public IReadOnlyList<RtpSourceContext> GetActiveSources()
+        => _sources.Values.ToList();
+
+    /// <summary>
+    /// Removes sources that have not received a packet within <see cref="SourceTimeoutMs"/>.
+    /// </summary>
+    public void PruneStale()
+    {
+        var threshold = (long)(SourceTimeoutMs / 1000.0 * Stopwatch.Frequency);
+        var now = Stopwatch.GetTimestamp();
+
+        foreach (var (ssrc, context) in _sources)
+        {
+            if (now - context.LastActivityTicks <= threshold)
+                continue;
+
+            if (_sources.TryRemove(ssrc, out var removed))
+            {
+                _logger.LogInformation("Pruned stale source SSRC={Ssrc:X8}", ssrc);
+                SourceExpired?.Invoke(ssrc);
+                removed.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Override the jitter buffer target size on all current (and future) sources.
+    /// </summary>
+    public void SetAllBufferSizes(int milliseconds)
+    {
+        foreach (var context in _sources.Values)
+            context.JitterBuffer.SetTargetBufferSize(milliseconds);
+    }
+
+    /// <summary>
+    /// Aggregate statistics across all active sources.
+    /// </summary>
+    public (int received, int lost, int late, int duplicate, int played,
+        double lossPercent, double jitterMs, double bufferMs, int buffered) GetStatistics()
+    {
+        var sources = GetActiveSources();
+        if (sources.Count == 0)
+            return (0, 0, 0, 0, 0, 0.0, 0.0, 0.0, 0);
+
+        int received = 0, lost = 0, late = 0, duplicate = 0, played = 0, buffered = 0;
+        double jitterSum = 0, bufferSum = 0;
+
+        foreach (var ctx in sources)
+        {
+            var s = ctx.JitterBuffer.GetStatistics();
+            received  += s.received;
+            lost      += s.lost;
+            late      += s.late;
+            duplicate += s.duplicate;
+            played    += s.played;
+            buffered  += s.buffered;
+            jitterSum += s.jitterMs;
+            bufferSum += s.bufferMs;
+        }
+
+        double lossPercent = (received + lost) > 0
+            ? 100.0 * lost / (received + lost)
+            : 0.0;
+
+        return (received, lost, late, duplicate, played,
+            lossPercent,
+            jitterSum  / sources.Count,   // average jitter across sources
+            bufferSum  / sources.Count,   // average buffer size across sources
+            buffered);
+    }
+
+    /// <summary>
+    /// Per-source statistics for diagnostics
+    /// </summary>
+    public IReadOnlyList<(uint ssrc, int received, int lost, double lossPercent, double jitterMs, double bufferMs, int buffered)>
+        GetPerSourceStatistics()
+    {
+        return GetActiveSources()
+            .Select(ctx =>
+            {
+                var s = ctx.JitterBuffer.GetStatistics();
+                return (ctx.Ssrc, s.received, s.lost, s.lossPercent, s.jitterMs, s.bufferMs, s.buffered);
+            })
+            .ToList();
+    }
+
+    public void Dispose()
+    {
+        foreach (var (_, context) in _sources)
+            context.Dispose();
+        _sources.Clear();
+    }
+}

--- a/OpenFreq.Common/RTPJitterbuffer.cs
+++ b/OpenFreq.Common/RTPJitterbuffer.cs
@@ -26,6 +26,7 @@ public class RtpJitterBuffer
         
     // State
     private ushort _nextExpectedSequence;
+    private bool _firstPacketPlayed; // true once _nextExpectedSequence has been seeded from real data
     private uint _baseTimestamp;
     private long _baseTimeTicks;
     private long _playoutStartTicks;
@@ -135,12 +136,6 @@ public class RtpJitterBuffer
         {
 
 
-            foreach (var kvp in _buffer.OrderBy(k => k.Key).Take(3))
-            {
-                var valuePlayoutTimestamp = kvp.Value.PlayoutTimestamp;
-                RtpPacket.TimestampDifference(playoutTimestamp, valuePlayoutTimestamp);
-            }
-
             // Find packets ready for playout
             var readyPackets = _buffer
                 .Where(kvp => RtpPacket.TimestampDifference(playoutTimestamp, kvp.Value.PlayoutTimestamp) >= 0)
@@ -156,8 +151,13 @@ public class RtpJitterBuffer
             nextPacket = readyPackets.First();
             _buffer.Remove(nextPacket.Key);
 
-            // Check if this is the expected sequence (loss detection)
-            if (nextPacket.Key != _nextExpectedSequence)
+            // Check if this is the expected sequence (loss detection).
+            // Skip the check on the first packet
+            if (!_firstPacketPlayed)
+            {
+                _firstPacketPlayed = true;
+            }
+            else if (nextPacket.Key != _nextExpectedSequence)
             {
                 var gap = RtpPacket.SequenceDifference(nextPacket.Key, _nextExpectedSequence);
                 if (gap > 0)
@@ -178,6 +178,9 @@ public class RtpJitterBuffer
 
             _nextExpectedSequence = (ushort)(nextPacket.Key + 1);
             _packetsPlayed++;
+
+            // Steer the playout clock towards the target buffer depth
+            AdjustPlayoutClock();
         }
 
         return nextPacket.Value.Packet;
@@ -253,19 +256,10 @@ public class RtpJitterBuffer
         double actualIntervalMs = (packet.ReceivedTicks - _lastPacketReceivedTicks) * 1000.0 / Stopwatch.Frequency;
         double expectedIntervalMs = expectedTimestampMs - _lastPacketTimestamp;
     
-        // Ignore abnormal timestamp deltas (first packet often has accumulated frames)
-        if (expectedIntervalMs > 150)
+        // Detect transmission gap (PTT released).
+        if (expectedIntervalMs > 500)
         {
-            _logger.LogWarning("Ignoring abnormal timestamp delta: {DeltaMs:F0}ms", expectedIntervalMs);
-            _lastPacketReceivedTicks = packet.ReceivedTicks;
-            _lastPacketTimestamp = expectedTimestampMs;
-            return;
-        }
-    
-        // Detect transmission gap (PTT released)
-        if (actualIntervalMs > 500 || expectedIntervalMs > 500)
-        {
-            _logger.LogInformation("Transmission gap detected ({IntervalMs:F0}ms), resetting jitter measurement", actualIntervalMs);
+            _logger.LogInformation("Transmission gap detected ({IntervalMs:F0}ms RTP delta), resetting jitter measurement", expectedIntervalMs);
             _jitterSamples.Clear();
             _measuredJitterMs = 0;
             _lastPacketReceivedTicks = packet.ReceivedTicks;
@@ -290,24 +284,52 @@ public class RtpJitterBuffer
     }
         
     /// <summary>
-    /// Adapt buffer size based on observed jitter
+    /// Adapt target buffer size based on observed jitter.
+    /// Uses asymmetric convergence: fast increase to protect against bursts,
+    /// slow decrease to avoid oscillation.
     /// </summary>
     private void AdaptBufferSize()
     {
         if (_jitterSamples.Count < 10)
             return;
-    
-        // Use 95th percentile instead of max (handles occasional spikes)
+
         var sortedJitter = _jitterSamples.OrderBy(x => x).ToList();
         int p95Index = (int)(sortedJitter.Count * 0.95);
         double jitter95 = sortedJitter[p95Index];
-    
-        // Target buffer = 4x p95 jitter, minimum 60ms
-        double targetBuffer = Math.Max(60, jitter95 * 4.0);
-    
-        // Adapt gradually (5% per adjustment = ~20 steps to converge)
+
+        // 2.5x p95 jitter is enough headroom for most conditions
+        double targetBuffer = Math.Max(MIN_BUFFER_MS, jitter95 * 2.5);
+
         double delta = targetBuffer - _targetBufferMs;
-        _targetBufferMs += delta * 0.05;
+        // Converge up quickly (protect against bursts), down slowly (avoid churn)
+        double rate = delta > 0 ? 0.15 : 0.03;
+        _targetBufferMs += delta * rate;
+        _targetBufferMs = Math.Clamp(_targetBufferMs, MIN_BUFFER_MS, MAX_BUFFER_MS);
+    }
+
+    /// <summary>
+    /// Nudges the playout clock to steer actual buffer depth towards the
+    /// target. Called each time a packet is dequeued so corrections are
+    /// applied incrementally rather than in a single jump.
+    /// Buffer deeper than target  → advance clock slightly (drain faster).
+    /// Buffer shallower than target → retard clock slightly (let it fill).
+    /// </summary>
+    private void AdjustPlayoutClock()
+    {
+        // _buffer is already locked by the caller (GetNextPacket)
+        int targetPackets = (int)Math.Round(_targetBufferMs / 20.0); // 20ms frames
+        int error = _buffer.Count - targetPackets;
+
+        if (Math.Abs(error) <= 1)
+            return;
+
+        // 1ms nudge per dequeued packet
+        long nudgeTicks = (long)(0.001 * Stopwatch.Frequency);
+
+        if (error > 1)
+            _playoutStartTicks -= nudgeTicks; // clock advances → releases packets sooner
+        else
+            _playoutStartTicks += nudgeTicks; // clock retards → holds packets longer
     }
     
         
@@ -350,6 +372,7 @@ public class RtpJitterBuffer
             _buffer.Clear();
             _jitterSamples.Clear();
             _initialized = false;
+            _firstPacketPlayed = false;
             _baseTimeTicks = 0;
             _playoutStartTicks = 0;
             _lastPacketReceivedTicks = 0;
@@ -362,9 +385,7 @@ public class RtpJitterBuffer
         }
     }
         
-    /// <summary>
-    /// Get current buffer size in milliseconds
-    /// </summary>
+   
     public double GetBufferSizeMs() => _targetBufferMs;
         
     /// <summary>

--- a/OpenFreq.Common/RTPJitterbuffer.cs
+++ b/OpenFreq.Common/RTPJitterbuffer.cs
@@ -317,7 +317,7 @@ public class RtpJitterBuffer
     private void AdjustPlayoutClock()
     {
         // _buffer is already locked by the caller (GetNextPacket)
-        int targetPackets = (int)Math.Round(_targetBufferMs / 20.0); // 20ms frames
+        int targetPackets = (int)Math.Round(_targetBufferMs / RtpAudioReceiver.PLAYOUT_INTERVAL_MS);
         int error = _buffer.Count - targetPackets;
 
         if (Math.Abs(error) <= 1)

--- a/OpenFreq.Common/RtpSourceContext.cs
+++ b/OpenFreq.Common/RtpSourceContext.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using Concentus.Structs;
+using Microsoft.Extensions.Logging;
+
+namespace OpenFreq.Common;
+
+/// <summary>
+/// Encapsulates all state belonging to a single RTP synchronization source (SSRC).
+/// Each concurrent talker gets an independent context so that jitter buffering,
+/// Opus decoder state, and loss-concealment tracking never cross-contaminate
+/// between streams.
+/// </summary>
+public sealed class RtpSourceContext : IDisposable
+{
+    public uint Ssrc { get; }
+    
+    public RtpJitterBuffer JitterBuffer { get; }
+    public OpusDecoder? OpusDecoder { get; }
+    
+    // Loss detection state
+    public ushort LastSequenceReceived { get; set; }
+    public bool FirstPacketReceived { get; set; }
+    
+    // Last valid metadata from this source, used to reconstruct concealment packets
+    public AudioPacketMetadata? LastValidMetadata { get; set; }
+    
+    // Used by the pool to prune sources that have gone silent
+    public long LastActivityTicks { get; set; }
+
+    public RtpSourceContext(uint ssrc, ILoggerFactory loggerFactory, bool opusEnabled, int initialBufferMs)
+    {
+        Ssrc = ssrc;
+        LastActivityTicks = Stopwatch.GetTimestamp();
+
+        JitterBuffer = new RtpJitterBuffer(loggerFactory.CreateLogger<RtpJitterBuffer>());
+        JitterBuffer.SetTargetBufferSize(initialBufferMs);
+
+        if (opusEnabled)
+        {
+            #pragma warning disable CS0618 // Using the new factory method will not work on Linux
+            OpusDecoder = new OpusDecoder(OpenFreqRtcClient.SAMPLE_RATE, OpenFreqRtcClient.CHANNELS);
+            #pragma warning restore CS0618
+        }
+    }
+
+    public void Dispose()
+    {
+        OpusDecoder?.Dispose();
+        JitterBuffer.Reset();
+    }
+}

--- a/OpenFreq.Server/AudioStreamServer.cs
+++ b/OpenFreq.Server/AudioStreamServer.cs
@@ -17,7 +17,7 @@ namespace OpenFreq.Server;
 public class AudioStreamServer
 {
     private readonly ConcurrentDictionary<string, AudioStreamSession> _sessions = new();
-    private readonly ConcurrentDictionary<string, ReceiverRtpState> _receiverRtpStates = new();
+    private readonly ConcurrentDictionary<(string clientId, uint Ssrc), ReceiverRtpState> _receiverRtpStates = new();
     private readonly FrequencyChannelManager _channelManager;
     private readonly ConcurrentDictionary<string, ClientSession> _clients;
     private readonly ILogger<AudioStreamServer> _logger;
@@ -25,9 +25,6 @@ public class AudioStreamServer
     private readonly int _basePort;
     private int _nextPortOffset = 0;
     private CancellationTokenSource _cts = new();
-    
-    // Server's SSRC (synchronization source identifier)
-    private readonly uint _serverSsrc = (uint)Random.Shared.Next();
 
     // High-performance logging delegates
     private static readonly Action<ILogger, string, int, Exception?> _logAudioSessionCreated =
@@ -60,7 +57,7 @@ public class AudioStreamServer
         _basePort = basePort;
         _udpManager = new UdpStreamManager(loggerFactory.CreateLogger<UdpStreamManager>());
         
-        _logger.LogInformation("AudioStreamServer initialized as RTP translator (SSRC: 0x{Ssrc:X8})", _serverSsrc);
+        _logger.LogInformation("AudioStreamServer initialized");
     }
 
     public async Task<int> CreateAudioSession(string clientId)
@@ -244,8 +241,9 @@ public class AudioStreamServer
         AudioPacketMetadata metadata,
         byte[] audioData)
     {
+        var senderSsrc = originalRtpPacket.Ssrc;
         // Get or create RTP state for this receiver
-        var rtpState = _receiverRtpStates.GetOrAdd(receiverClientId, _ => new ReceiverRtpState
+        var rtpState = _receiverRtpStates.GetOrAdd((receiverClientId, senderSsrc), _ => new ReceiverRtpState
         {
             NextSequence = 0,
             PacketsSent = 0
@@ -256,14 +254,14 @@ public class AudioStreamServer
         var metadataJson = Json.Instance.Serialize(metadata);
         var metadataBytes = Encoding.UTF8.GetBytes(metadataJson);
 
-        // Create new RTP packet with server's sequence number and SSRC
+        // Create new RTP packet with server's sequence number
         var rtpPacket = new RtpPacket
         {
             Version = 2,
             PayloadType = originalRtpPacket.PayloadType,  // Preserve payload type (Opus/PCM)
             SequenceNumber = rtpState.NextSequence,       // SERVER's sequence for this receiver
             Timestamp = originalRtpPacket.Timestamp,      // Preserve original timestamp for jitter calc
-            Ssrc = _serverSsrc,                           // Server is the source
+            Ssrc = originalRtpPacket.Ssrc,                // Preserve original SSRC
             Marker = originalRtpPacket.Marker,            // Currently unused but still preserve it
             ExtensionProfile = RtpPacket.OpenFreqProfile,
             ExtensionData = metadataBytes,
@@ -323,10 +321,11 @@ public class AudioStreamServer
             _udpManager.RemoveClient(clientId);
             session.UdpClient.Close();
             session.UdpClient.Dispose();
-            
-            // Clean up RTP state
-            _receiverRtpStates.TryRemove(clientId, out _);
-            
+
+            // Remove all per-SSRC RTP states for this receiver
+            foreach (var key in _receiverRtpStates.Keys.Where(k => k.clientId == clientId).ToList())
+                _receiverRtpStates.TryRemove(key, out _);
+
             _logSessionRemoved(_logger, clientId, null);
         }
     }
@@ -339,18 +338,17 @@ public class AudioStreamServer
     /// <summary>
     /// Get RTP statistics for a receiver
     /// </summary>
-    public ReceiverRtpStats? GetReceiverRtpStats(string clientId)
+    public IEnumerable<ReceiverRtpStats> GetReceiverRtpStats(string clientId)
     {
-        if (_receiverRtpStates.TryGetValue(clientId, out var state))
-        {
-            return new ReceiverRtpStats
+        return _receiverRtpStates
+            .Where(kvp => kvp.Key.clientId == clientId)
+            .Select(kvp => new ReceiverRtpStats
             {
                 ClientId = clientId,
-                PacketsSent = state.PacketsSent,
-                CurrentSequence = state.NextSequence
-            };
-        }
-        return null;
+                Ssrc = kvp.Key.Ssrc,
+                PacketsSent = kvp.Value.PacketsSent,
+                CurrentSequence = kvp.Value.NextSequence
+            });
     }
 
     public void Stop()
@@ -385,6 +383,9 @@ public class ReceiverRtpState
 public class ReceiverRtpStats
 {
     public string ClientId { get; set; } = "";
+    
+    public uint Ssrc {get; set; }
+    
     public long PacketsSent { get; set; }
     public ushort CurrentSequence { get; set; }
 }


### PR DESCRIPTION
Server: does not overwrite SSRC but forwards the original one. Uses packet counters per SSRC/per Client
Client: One jitter buffer per incoming SSRC, managed in the RTPJitterBufferPool. Also one OpusDecoder per client etc (RtpSourceContext)