### PR TITLE
Reduce latency

### DIFF
--- a/OpenFreq.Client/Services/OpenFreqService.cs
+++ b/OpenFreq.Client/Services/OpenFreqService.cs
@@ -400,9 +400,9 @@ public class OpenFreqService : IOpenFreqService
 
             _recordHandle = Bass.RecordStart(
                 OpenFreqRtcClient.SAMPLE_RATE,
-                OpenFreqRtcClient.CHANNELS,
+                1,
                 BassFlags.RecordPause,
-                Period: 20,
+                Period: 5,
                 RecordProcedure);
 
             if (_recordHandle == 0)
@@ -540,7 +540,7 @@ public class OpenFreqService : IOpenFreqService
             // Calculate expected size for 20ms at 48kHz, mono, 16-bit
             // 48000 samples/sec ÷ 50 = 960 samples per 20ms
             // 960 samples × 2 bytes/sample × 1 channel = 1920 bytes
-            int expectedBytes = (OpenFreqRtcClient.SAMPLE_RATE / 50) * 2 * OpenFreqRtcClient.CHANNELS;
+            int expectedBytes = (OpenFreqRtcClient.SAMPLE_RATE / 50) * 2;
 
             // TODO: I dont think we need this anymore with the shorter dsp updates. Deactivated for now
             expectedBytes = 10000;
@@ -559,8 +559,8 @@ public class OpenFreqService : IOpenFreqService
             }
 
             // Copy audio data once
-            byte[] audioData = new byte[length];
-            Marshal.Copy(buffer, audioData, 0, length);
+            short[] audioData = new short[length / 2];
+            Marshal.Copy(buffer, audioData, 0, audioData.Length);
 
             // Send to ALL active frequencies
             var frequenciesData =
@@ -760,7 +760,7 @@ public class OpenFreqService : IOpenFreqService
         _playbackService?.StartPushStream(
             streamId,
             OpenFreqRtcClient.SAMPLE_RATE,
-            OpenFreqRtcClient.CHANNELS,
+            1,
             audioParams
         );
 
@@ -855,12 +855,12 @@ public class OpenFreqService : IOpenFreqService
                 if (!streamExists)
                 {
                     _logger.LogDebug(
-                        $"Creating new stream: {streamId}, SR={OpenFreqRtcClient.SAMPLE_RATE}, CH={OpenFreqRtcClient.CHANNELS}");
+                        $"Creating new stream: {streamId}, SR={OpenFreqRtcClient.SAMPLE_RATE}");
 
                     _playbackService?.StartPushStream(
                         streamId,
                         OpenFreqRtcClient.SAMPLE_RATE,
-                        OpenFreqRtcClient.CHANNELS,
+                        1,
                         audioParams);
                 }
                 else
@@ -879,9 +879,7 @@ public class OpenFreqService : IOpenFreqService
             }
             
             // Push audio data immediately
-            _playbackService?.PushAudioData(streamId, e.AudioData,
-                frequencyTransmission.BeginMarker,
-                frequencyTransmission.EndMarker, ambientNoiseType);
+            _playbackService?.PushAudioData(streamId, e.AudioData, ambientNoiseType);
         }
     }
 

--- a/OpenFreq.Client/ViewModels/MainWindowViewModel.cs
+++ b/OpenFreq.Client/ViewModels/MainWindowViewModel.cs
@@ -555,6 +555,7 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
             FalconRadioSharedMemoryServiceOnConnectionParametersChanged;
         _falconSharedMemoryService.FlyingStateChanged -= OnFlyingStateChanged;
 
+        await DisconnectAsync();
         ChannelList.Dispose();
         _openFreqService.Dispose();
         _hotkeyService.Dispose();

--- a/OpenFreq.Common/OpenFreqRtcClient.cs
+++ b/OpenFreq.Common/OpenFreqRtcClient.cs
@@ -32,6 +32,9 @@ public class OpenFreqRtcClient : IDisposable
     private RtpAudioReceiver? _rtpReceiver;
     private RtpAudioSender? _rtpSender;
 
+    // set by the server
+    private bool _opusCompressionEnabled = true;
+
     // Connection state
     public readonly string ServerIp;
     private readonly string _password;
@@ -114,11 +117,13 @@ public class OpenFreqRtcClient : IDisposable
                 logger:  _loggerFactory.CreateLogger<RtpAudioSender>(),
                 serverHost: ipPort.ipAddress,
                 serverPort: _audioPort,
-                clid: clientId
+                clid: clientId,
+                opusEnabled: _opusCompressionEnabled
             );
 
             _rtpReceiver = new RtpAudioReceiver(_loggerFactory,
                 udpClient: _rtpSender.UdpClient,
+                opusEnabled: _opusCompressionEnabled,
                 initialBufferMs: 150
             );
 
@@ -377,6 +382,8 @@ public class OpenFreqRtcClient : IDisposable
                         _myPeerId = success.PeerId;
                         _audioPort = success.AudioPort ?? 0;
                         _isAuthenticated = true;
+                        _opusCompressionEnabled = success.OpusCompressionEnabled;
+                        _logger.LogDebug("Opus compression enabled: " + _opusCompressionEnabled);
                         OnConnectionStateChanged(ConnectionState.Authenticated);
                         OnAuthenticated(_myPeerId, _audioPort);
                     }

--- a/OpenFreq.Common/OpenFreqRtcClient.cs
+++ b/OpenFreq.Common/OpenFreqRtcClient.cs
@@ -13,9 +13,8 @@ public class OpenFreqRtcClient : IDisposable
 {
     // Audio configuration constants
     public const int SAMPLE_RATE = RadioPlayback.SampleRate;
-    public const int CHANNELS = 1;
     public const int FRAME_SIZE_MS = 20;
-    public const int OPUS_SAMPLES_PER_FRAME = SAMPLE_RATE / (1000 / FRAME_SIZE_MS) * CHANNELS;
+    public const int OPUS_SAMPLES_PER_FRAME = SAMPLE_RATE / (1000 / FRAME_SIZE_MS);
     public const int DEFAULT_PORT = 9987;
 
     // Events for UI integration
@@ -33,9 +32,6 @@ public class OpenFreqRtcClient : IDisposable
     private RtpAudioReceiver? _rtpReceiver;
     private RtpAudioSender? _rtpSender;
 
-    // set by the server
-    private bool _opusCompressionEnabled = true;
-
     // Connection state
     public readonly string ServerIp;
     private readonly string _password;
@@ -45,7 +41,7 @@ public class OpenFreqRtcClient : IDisposable
     private bool _isConnected;
     private bool _isAuthenticated;
     private CancellationTokenSource _cts = new();
-    private string clientId = Guid.NewGuid().ToString();
+    private readonly string clientId = Guid.NewGuid().ToString();
 
     // Transmission state
     private readonly Dictionary<int, bool> _frequencyTransmissionState = new();
@@ -118,12 +114,11 @@ public class OpenFreqRtcClient : IDisposable
                 logger:  _loggerFactory.CreateLogger<RtpAudioSender>(),
                 serverHost: ipPort.ipAddress,
                 serverPort: _audioPort,
-                opusEnabled: _opusCompressionEnabled
+                clid: clientId
             );
 
             _rtpReceiver = new RtpAudioReceiver(_loggerFactory,
                 udpClient: _rtpSender.UdpClient,
-                opusEnabled: _opusCompressionEnabled,
                 initialBufferMs: 150
             );
 
@@ -236,11 +231,10 @@ public class OpenFreqRtcClient : IDisposable
         }
 
         // Send final silent packet with endMarker
-        var silence = new byte[OPUS_SAMPLES_PER_FRAME * 2]; // 20ms silence, 16-bit PCM
+        var silence = new short[OPUS_SAMPLES_PER_FRAME]; // 20ms silence, 16-bit PCM
         
         _rtpSender?.SendAudio(
             audioData: silence,
-            clientId: clientId,
             frequencyTransmissions: [new FrequencyTransmission(frequencyKhz, 0, 0, new Vector3(), null, false, true)]
         );
         
@@ -254,7 +248,7 @@ public class OpenFreqRtcClient : IDisposable
     }
 
 
-    public void SendAudio(byte[] pcmData, List<(int frequencyKhz, double txPowerWatts, double ppm, Vector3? position, Vector3? velocity, AmbientNoiseType ambientNoiseType)> frequencies, bool in3d)
+    public void SendAudio(Memory<short> pcmData, List<(int frequencyKhz, double txPowerWatts, double ppm, Vector3? position, Vector3? velocity, AmbientNoiseType ambientNoiseType)> frequencies, bool in3d)
     {
         var frequencyTransmissions = new List<FrequencyTransmission>();
         foreach (var freq in frequencies)
@@ -276,7 +270,7 @@ public class OpenFreqRtcClient : IDisposable
                 _frequencyFirstPacketSent[freq.frequencyKhz] = true;
         }
         
-        _rtpSender?.SendAudio(pcmData, clientId, frequencyTransmissions);
+        _rtpSender?.SendAudio(pcmData, frequencyTransmissions);
     }
     
 
@@ -383,8 +377,6 @@ public class OpenFreqRtcClient : IDisposable
                         _myPeerId = success.PeerId;
                         _audioPort = success.AudioPort ?? 0;
                         _isAuthenticated = true;
-                        _opusCompressionEnabled = success.OpusCompressionEnabled;
-                        _logger.LogDebug("Opus compression enabled: " + _opusCompressionEnabled);
                         OnConnectionStateChanged(ConnectionState.Authenticated);
                         OnAuthenticated(_myPeerId, _audioPort);
                     }

--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -30,6 +30,7 @@ public class RtpAudioReceiver : IDisposable
     private readonly ILogger<RtpAudioReceiver> _logger;
     private readonly UdpClient _udpClient;
     private readonly RtpJitterBufferPool _pool;
+    private readonly bool _opusEnabled;
     private readonly CancellationTokenSource _cts = new();
     private readonly Timer _playoutTimer;
 
@@ -43,17 +44,20 @@ public class RtpAudioReceiver : IDisposable
     private const int OPUS_FRAME_SAMPLES = 960; // 20ms at 48kHz (matches sender)
     public static int PLAYOUT_INTERVAL_MS = 20;
 
-    public RtpAudioReceiver(ILoggerFactory loggerFactory, UdpClient udpClient, int initialBufferMs = 150)
+    public RtpAudioReceiver(ILoggerFactory loggerFactory, UdpClient udpClient, bool opusEnabled = true,
+        int initialBufferMs = 150)
     {
         _logger = loggerFactory.CreateLogger<RtpAudioReceiver>();
+        _opusEnabled = opusEnabled;
 
-        _pool = new RtpJitterBufferPool(loggerFactory, initialBufferMs);
+        _pool = new RtpJitterBufferPool(loggerFactory, opusEnabled, initialBufferMs);
         _pool.SourceAdded += ssrc => _logger.LogInformation("Source joined:  SSRC={Ssrc:X8}", ssrc);
         _pool.SourceExpired += ssrc => _logger.LogInformation("Source expired: SSRC={Ssrc:X8}", ssrc);
 
         _udpClient = udpClient;
         var port = (_udpClient.Client.LocalEndPoint as IPEndPoint)!.Port;
         _logger.LogInformation("Started on port {Port}", port);
+        _logger.LogInformation("  Opus: {OpusEnabled}", _opusEnabled);
         _logger.LogInformation("  Initial buffer: {BufferMs}ms (adaptive, per-SSRC)", initialBufferMs);
 
         Task.Run(() => ReceiveLoop(), _cts.Token);
@@ -210,9 +214,16 @@ public class RtpAudioReceiver : IDisposable
             context.LastValidMetadata = metadata;
 
             byte[] decodedAudio;
-            decodedAudio = DecodeOpus(packet.Payload, context.OpusDecoder, isLost: false, decodeFec: false);
-            if (decodedAudio.Length == 0)
-                return;
+            if (_opusEnabled && context.OpusDecoder != null)
+            {
+                decodedAudio = DecodeOpus(packet.Payload, context.OpusDecoder, isLost: false, decodeFec: false);
+                if (decodedAudio.Length == 0)
+                    return;
+            }
+            else
+            {
+                decodedAudio = packet.Payload;
+            }
 
             #if DEBUG
             _logger.LogDebug($"Playing packet from {packet.Ssrc}: {packet.SequenceNumber}");

--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -30,7 +30,6 @@ public class RtpAudioReceiver : IDisposable
     private readonly ILogger<RtpAudioReceiver> _logger;
     private readonly UdpClient _udpClient;
     private readonly RtpJitterBufferPool _pool;
-    private readonly bool _opusEnabled;
     private readonly CancellationTokenSource _cts = new();
     private readonly Timer _playoutTimer;
 
@@ -44,20 +43,17 @@ public class RtpAudioReceiver : IDisposable
     private const int OPUS_FRAME_SAMPLES = 960; // 20ms at 48kHz (matches sender)
     public static int PLAYOUT_INTERVAL_MS = 20;
 
-    public RtpAudioReceiver(ILoggerFactory loggerFactory, UdpClient udpClient, bool opusEnabled = true,
-        int initialBufferMs = 150)
+    public RtpAudioReceiver(ILoggerFactory loggerFactory, UdpClient udpClient, int initialBufferMs = 150)
     {
         _logger = loggerFactory.CreateLogger<RtpAudioReceiver>();
-        _opusEnabled = opusEnabled;
 
-        _pool = new RtpJitterBufferPool(loggerFactory, opusEnabled, initialBufferMs);
+        _pool = new RtpJitterBufferPool(loggerFactory, initialBufferMs);
         _pool.SourceAdded += ssrc => _logger.LogInformation("Source joined:  SSRC={Ssrc:X8}", ssrc);
         _pool.SourceExpired += ssrc => _logger.LogInformation("Source expired: SSRC={Ssrc:X8}", ssrc);
 
         _udpClient = udpClient;
         var port = (_udpClient.Client.LocalEndPoint as IPEndPoint)!.Port;
         _logger.LogInformation("Started on port {Port}", port);
-        _logger.LogInformation("  Opus: {OpusEnabled}", _opusEnabled);
         _logger.LogInformation("  Initial buffer: {BufferMs}ms (adaptive, per-SSRC)", initialBufferMs);
 
         Task.Run(() => ReceiveLoop(), _cts.Token);
@@ -214,16 +210,9 @@ public class RtpAudioReceiver : IDisposable
             context.LastValidMetadata = metadata;
 
             byte[] decodedAudio;
-            if (_opusEnabled && context.OpusDecoder != null)
-            {
-                decodedAudio = DecodeOpus(packet.Payload, context.OpusDecoder, isLost: false, decodeFec: false);
-                if (decodedAudio.Length == 0)
-                    return;
-            }
-            else
-            {
-                decodedAudio = packet.Payload;
-            }
+            decodedAudio = DecodeOpus(packet.Payload, context.OpusDecoder, isLost: false, decodeFec: false);
+            if (decodedAudio.Length == 0)
+                return;
 
             #if DEBUG
             _logger.LogDebug($"Playing packet from {packet.Ssrc}: {packet.SequenceNumber}");
@@ -246,9 +235,6 @@ public class RtpAudioReceiver : IDisposable
     /// </summary>
     private void GenerateConcealmentAudio(ushort lostSequence, RtpPacket? nextPacket, RtpSourceContext context)
     {
-        if (!_opusEnabled || context.OpusDecoder == null)
-            return;
-
         try
         {
             byte[] concealmentAudio;

--- a/OpenFreq.Common/RTPAudioSender.cs
+++ b/OpenFreq.Common/RTPAudioSender.cs
@@ -3,10 +3,10 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Text.Json;
-using Concentus;
 using Concentus.Enums;
 using Concentus.Structs;
 using Microsoft.Extensions.Logging;
+using OpenFreqAudio;
 using OpenFreq.Common.Rtp;
 
 namespace OpenFreq.Common;
@@ -20,43 +20,29 @@ public class RtpAudioSender : IDisposable
     private readonly ILogger<RtpAudioSender> _logger;
     private const int OPUS_FRAME_SIZE = OpenFreqRtcClient.OPUS_SAMPLES_PER_FRAME;
 
-    private readonly byte[]
-        _audioBuffer = new byte[OPUS_FRAME_SIZE * 2 * OpenFreqRtcClient.CHANNELS]; // x2 for 16-bit, channels
-
-    private int _bufferPosition = 0;
 
     private readonly UdpClient _udpClient;
     public UdpClient UdpClient => _udpClient;
     private readonly IPEndPoint _serverEndpoint;
-    private readonly OpusEncoder? _opusEncoder;
-    private readonly bool _opusEnabled;
+
+#pragma warning disable CS0618 // Do not use the factory - it does not work with Linux
+    private readonly OpusEncoder _opusEncoder = new OpusEncoder(
+            OpenFreqRtcClient.SAMPLE_RATE,
+            1,
+            OpusApplication.OPUS_APPLICATION_RESTRICTED_LOWDELAY
+        );
+#pragma warning restore CS0618 // Type or member is obsolete
 
     // RTP state
-    private ushort _sequenceNumber = 0;
-    private uint _timestamp = 0;
+    private volatile List<FrequencyTransmission> _frequencies = [];
     private readonly uint _ssrc;
+    private readonly string _clientId;
     private const byte PAYLOAD_TYPE_OPUS = 96;
-    private const byte PAYLOAD_TYPE_PCMU = 0;
 
-    // Queued audio data structure (raw PCM, not encoded yet)
-    private struct QueuedAudio
-    {
-        public byte[] PcmData;
-        public string ClientId;
-        public List<FrequencyTransmission> FrequencyTransmissions;
-        public uint Timestamp;
-        public ushort SequenceNumber;
-    }
+    // Sending Queue - now holds raw PCM data, encoding happens in the send thread
+    private readonly SyncRope<short> _sendQueue = new();
 
-    // Sending Queue - now holds raw PCM data, encoding happens in pacing timer
-    private readonly Queue<QueuedAudio> _sendQueue = new Queue<QueuedAudio>();
-
-    private System.Timers.Timer? _pacingTimer;
-    private readonly object _queueLock = new object();
-
-    // Reusable buffers to avoid allocations in pacing timer
-    private readonly byte[] _opusBuffer = new byte[4000];
-    private readonly short[] _pcmSamples = new short[OPUS_FRAME_SIZE * OpenFreqRtcClient.CHANNELS];
+    private readonly Thread? _sendThread;
 
     // Statistics
     private int _packetsSent = 0;
@@ -65,21 +51,21 @@ public class RtpAudioSender : IDisposable
     /// <summary>
     /// Create RTP audio sender
     /// </summary>
-    public RtpAudioSender(ILogger<RtpAudioSender> logger, string serverHost, int serverPort, bool opusEnabled = true)
+    public RtpAudioSender(ILogger<RtpAudioSender> logger, string serverHost, int serverPort, string clid)
     {
         _logger = logger;
-        _opusEnabled = opusEnabled;
         _serverEndpoint = new IPEndPoint(IPAddress.Parse(serverHost), serverPort);
         _udpClient = new UdpClient();
 
         // Generate unique SSRC (synchronization source identifier)
         _ssrc = (uint)Random.Shared.Next();
+        _clientId = clid;
 
         // Send empty RTP keepalive packet to register our port
         var keepalive = new RtpPacket
         {
             Version = 2,
-            PayloadType = _opusEnabled ? PAYLOAD_TYPE_OPUS : PAYLOAD_TYPE_PCMU,
+            PayloadType = PAYLOAD_TYPE_OPUS,
             SequenceNumber = 0,
             Timestamp = 0,
             Ssrc = _ssrc,
@@ -87,50 +73,17 @@ public class RtpAudioSender : IDisposable
         };
         _udpClient.Send(keepalive.ToBytes(), _serverEndpoint);
 
-        if (_opusEnabled)
-        {
-            try
-            {
-#pragma warning disable CS0618 // Do not use the factory - it does not work with Linux
-                _opusEncoder = new OpusEncoder(
-                    OpenFreqRtcClient.SAMPLE_RATE,
-                    OpenFreqRtcClient.CHANNELS,
-                    OpusApplication.OPUS_APPLICATION_RESTRICTED_LOWDELAY
-                );
-#pragma warning restore CS0618 // Type or member is obsolete
-            }
-            catch (OpusException ex)
-            {
-                // This is the Opus error code
-                _logger.LogError("Opus error: {OpusErrorCode}", ex.OpusErrorCode);
-                _logger.LogError("Message: {Message}", ex.Message);
-            }
+        _opusEncoder.Bitrate = 24000;
+        _opusEncoder.Complexity = 8;
+        _opusEncoder.SignalType = OpusSignal.OPUS_SIGNAL_VOICE;
+        _opusEncoder.UseInbandFEC = true;
+        _opusEncoder.PacketLossPercent = 15;
 
-            if (_opusEncoder == null)
-            {
-                _logger.LogError("Could not create OpusEncoder");
-                return;
-            }
-            else
-            {
-                _opusEncoder.Bitrate = 98000;
-                _opusEncoder.Complexity = 8;
-                _opusEncoder.SignalType = OpusSignal.OPUS_SIGNAL_MUSIC;
-                _opusEncoder.UseInbandFEC = true;
-                _opusEncoder.PacketLossPercent = 15;
-                _opusEncoder.ForceMode = OpusMode.MODE_SILK_ONLY;
-            }
-        }
-
-        // Start pacing timer - sends one packet every 10ms
-        _pacingTimer = new System.Timers.Timer(10); // 10ms interval
-        _pacingTimer.Elapsed += OnPacingTimerElapsed;
-        _pacingTimer.AutoReset = true;
-        _pacingTimer.Start();
+        _sendThread = new Thread(SendThreadProc);
+        _sendThread.Start();
 
         _logger.LogInformation("Initialized");
         _logger.LogInformation("  Server: {ServerHost}:{ServerPort}", serverHost, serverPort);
-        _logger.LogInformation("  Opus: {OpusEnabled}", _opusEnabled);
         _logger.LogInformation("  SSRC: 0x{Ssrc:X8}", _ssrc);
     }
 
@@ -143,125 +96,40 @@ public class RtpAudioSender : IDisposable
     /// <param name="position">Aircraft position</param>
     /// <param name="frequencyTransmissions">List of FrequencyTransmissions</param>
     /// 
-    public void SendAudio(byte[] audioData, string clientId, List<FrequencyTransmission> frequencyTransmissions)
+    public void SendAudio(Memory<short> audioData, List<FrequencyTransmission> frequencyTransmissions)
     {
-        try
-        {
-            int offset = 0;
-            bool isFirstChunk = true;
-
-            // Process all incoming data in chunks
-            while (offset < audioData.Length)
-            {
-                int bytesToCopy = Math.Min(
-                    audioData.Length - offset,
-                    _audioBuffer.Length - _bufferPosition
-                );
-
-                Buffer.BlockCopy(audioData, offset, _audioBuffer, _bufferPosition, bytesToCopy);
-                _bufferPosition += bytesToCopy;
-                offset += bytesToCopy;
-
-                // If we have a complete frame, queue it
-                if (_bufferPosition >= _audioBuffer.Length)
-                {
-                    // First chunk uses original markers, subsequent chunks clear beginMarkers
-                    var markers = isFirstChunk
-                        ? frequencyTransmissions
-                        : frequencyTransmissions.Select(f => new FrequencyTransmission(f.Khz, f.TxPowerWatts, f.Ppm,
-                            f.Position, f.Velocity, false, f.BeginMarker, f.EndMarker, f.AmbientNoiseType)).ToList();
-
-                    QueueRawFrame(clientId, markers);
-                    isFirstChunk = false;
-                    _bufferPosition = 0;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error in SendAudio");
-        }
+        _frequencies = frequencyTransmissions;
+        _sendQueue.Fill(audioData);
     }
 
-    private void QueueRawFrame(string clientId, List<FrequencyTransmission> frequencyTransmissions)
+    private void SendThreadProc()
     {
-        // Copy the buffer data (must copy since _audioBuffer will be reused)
-        var pcmCopy = new byte[_audioBuffer.Length];
-        Buffer.BlockCopy(_audioBuffer, 0, pcmCopy, 0, _audioBuffer.Length);
+        uint timestamp = 0;
+        ushort sequence = 0;
+        var drainbuf = new short[OPUS_FRAME_SIZE];
+        var encoded = new byte[OPUS_FRAME_SIZE * 2];
+        var encspan = new Memory<byte>();
 
-        var queued = new QueuedAudio
+        while (true)
         {
-            PcmData = pcmCopy,
-            ClientId = clientId,
-            FrequencyTransmissions = frequencyTransmissions,
-            Timestamp = _timestamp,
-            SequenceNumber = _sequenceNumber,
-        };
-
-        lock (_queueLock)
-        {
-            _sendQueue.Enqueue(queued);
-        }
-
-        // Update RTP state
-        _sequenceNumber++;
-        _timestamp += (uint)OPUS_FRAME_SIZE;
-        _packetsSent++;
-    }
-
-    private void OnPacingTimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
-    {
-        QueuedAudio? queued;
-
-        lock (_queueLock)
-        {
-            if (_sendQueue.Count == 0)
-                return;
-
-            queued = _sendQueue.Dequeue();
-        }
-
-        try
-        {
-            var queuedValue = queued.Value;
+            var dspan = new Memory<short>(drainbuf);
+            if (!_sendQueue.DrainExactly(dspan.Span)) return;
+            ushort nextSequence = (ushort)(sequence + dspan.Length);
 
             // Encode audio (happens here, not in audio callback)
-            byte[] encodedAudio;
-            if (_opusEnabled && _opusEncoder != null)
+            encspan = new Memory<byte>(encoded);
+            var opusBytes = _opusEncoder.Encode(dspan.Span, dspan.Length, encspan.Span, encspan.Length);
+            if (opusBytes <= 0)
             {
-                // Convert byte[] to short[] using reusable buffer
-                Buffer.BlockCopy(queuedValue.PcmData, 0, _pcmSamples, 0, queuedValue.PcmData.Length);
-
-                // Encode to Opus using reusable buffer
-                var opusBytes = _opusEncoder.Encode(
-                    _pcmSamples,
-                    0,
-                    OPUS_FRAME_SIZE, // Samples per channel
-                    _opusBuffer,
-                    0,
-                    _opusBuffer.Length
-                );
-
-                if (opusBytes <= 0)
-                {
-                    _logger.LogWarning("Opus encode failed");
-                    return;
-                }
-
-                encodedAudio = new byte[opusBytes];
-                Array.Copy(_opusBuffer, encodedAudio, opusBytes);
+                throw new Exception("Opus encode failed");
             }
-            else
-            {
-                // Raw PCM
-                encodedAudio = queuedValue.PcmData;
-            }
+            encspan = encspan[..opusBytes];
 
             // Build metadata
             var metadata = new AudioPacketMetadata
             {
-                ClientId = queuedValue.ClientId,
-                Frequencies = queuedValue.FrequencyTransmissions,
+                ClientId = _clientId,
+                Frequencies = _frequencies,
             };
 
             var metadataJson = JsonSerializer.Serialize(metadata, OpenFreqJsonContext.Default.AudioPacketMetadata);
@@ -271,22 +139,19 @@ public class RtpAudioSender : IDisposable
             var rtpPacket = new RtpPacket
             {
                 Version = 2,
-                PayloadType = _opusEnabled ? PAYLOAD_TYPE_OPUS : PAYLOAD_TYPE_PCMU,
-                SequenceNumber = queuedValue.SequenceNumber,
-                Timestamp = queuedValue.Timestamp,
+                PayloadType = PAYLOAD_TYPE_OPUS,
+                SequenceNumber = sequence,
+                Timestamp = timestamp,
                 Ssrc = _ssrc,
                 ExtensionProfile = RtpPacket.OpenFreqProfile,
                 ExtensionData = metadataBytes,
-                Payload = encodedAudio
+                Payload = encspan.ToArray()
             };
 
             // Send the packet
             var rtpBytes = rtpPacket.ToBytes();
             _udpClient.Send(rtpBytes, rtpBytes.Length, _serverEndpoint);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Pacing timer error");
+            sequence = nextSequence;
         }
     }
 
@@ -302,8 +167,8 @@ public class RtpAudioSender : IDisposable
 
     public void Dispose()
     {
-        _pacingTimer?.Stop();
-        _pacingTimer?.Dispose();
+        _sendQueue.Close(); // Sentinel kills the thread
+        _sendThread?.Join();
         _udpClient.Close();
         _udpClient.Dispose();
         _opusEncoder?.Dispose();

--- a/OpenFreq.Common/RTPAudioSender.cs
+++ b/OpenFreq.Common/RTPAudioSender.cs
@@ -8,6 +8,7 @@ using Concentus.Structs;
 using Microsoft.Extensions.Logging;
 using OpenFreqAudio;
 using OpenFreq.Common.Rtp;
+using System.Runtime.InteropServices;
 
 namespace OpenFreq.Common;
 
@@ -24,6 +25,7 @@ public class RtpAudioSender : IDisposable
     private readonly UdpClient _udpClient;
     public UdpClient UdpClient => _udpClient;
     private readonly IPEndPoint _serverEndpoint;
+    private readonly bool _opusEnabled;
 
 #pragma warning disable CS0618 // Do not use the factory - it does not work with Linux
     private readonly OpusEncoder _opusEncoder = new OpusEncoder(
@@ -38,6 +40,7 @@ public class RtpAudioSender : IDisposable
     private readonly uint _ssrc;
     private readonly string _clientId;
     private const byte PAYLOAD_TYPE_OPUS = 96;
+    private const byte PAYLOAD_TYPE_PCMU = 0;
 
     // Sending Queue - now holds raw PCM data, encoding happens in the send thread
     private readonly SyncRope<short> _sendQueue = new();
@@ -51,9 +54,10 @@ public class RtpAudioSender : IDisposable
     /// <summary>
     /// Create RTP audio sender
     /// </summary>
-    public RtpAudioSender(ILogger<RtpAudioSender> logger, string serverHost, int serverPort, string clid)
+    public RtpAudioSender(ILogger<RtpAudioSender> logger, string serverHost, int serverPort, string clid, bool opusEnabled = true)
     {
         _logger = logger;
+        _opusEnabled = opusEnabled;
         _serverEndpoint = new IPEndPoint(IPAddress.Parse(serverHost), serverPort);
         _udpClient = new UdpClient();
 
@@ -65,7 +69,7 @@ public class RtpAudioSender : IDisposable
         var keepalive = new RtpPacket
         {
             Version = 2,
-            PayloadType = PAYLOAD_TYPE_OPUS,
+            PayloadType = _opusEnabled ? PAYLOAD_TYPE_OPUS : PAYLOAD_TYPE_PCMU,
             SequenceNumber = 0,
             Timestamp = 0,
             Ssrc = _ssrc,
@@ -84,6 +88,7 @@ public class RtpAudioSender : IDisposable
 
         _logger.LogInformation("Initialized");
         _logger.LogInformation("  Server: {ServerHost}:{ServerPort}", serverHost, serverPort);
+        _logger.LogInformation("  Opus: {OpusEnabled}", _opusEnabled);
         _logger.LogInformation("  SSRC: 0x{Ssrc:X8}", _ssrc);
     }
 
@@ -118,12 +123,19 @@ public class RtpAudioSender : IDisposable
 
             // Encode audio (happens here, not in audio callback)
             encspan = new Memory<byte>(encoded);
-            var opusBytes = _opusEncoder.Encode(dspan.Span, dspan.Length, encspan.Span, encspan.Length);
-            if (opusBytes <= 0)
+            if (_opusEnabled)
             {
-                throw new Exception("Opus encode failed");
+                var opusBytes = _opusEncoder.Encode(dspan.Span, dspan.Length, encspan.Span, encspan.Length);
+                if (opusBytes <= 0)
+                {
+                    throw new Exception("Opus encode failed");
+                }
+                encspan = encspan[..opusBytes];
             }
-            encspan = encspan[..opusBytes];
+            else
+            {
+                MemoryMarshal.AsBytes(dspan.Span).CopyTo(encspan.Span);
+            }
 
             // Build metadata
             var metadata = new AudioPacketMetadata
@@ -139,7 +151,7 @@ public class RtpAudioSender : IDisposable
             var rtpPacket = new RtpPacket
             {
                 Version = 2,
-                PayloadType = PAYLOAD_TYPE_OPUS,
+                PayloadType = _opusEnabled ? PAYLOAD_TYPE_OPUS : PAYLOAD_TYPE_PCMU,
                 SequenceNumber = sequence,
                 Timestamp = timestamp,
                 Ssrc = _ssrc,

--- a/OpenFreq.Common/RTPJitterBufferPool.cs
+++ b/OpenFreq.Common/RTPJitterBufferPool.cs
@@ -12,6 +12,7 @@ public sealed class RtpJitterBufferPool : IDisposable
 {
     private readonly ILogger<RtpJitterBufferPool> _logger;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly bool _opusEnabled;
     private readonly int _initialBufferMs;
 
     private readonly ConcurrentDictionary<uint, RtpSourceContext> _sources = new();
@@ -27,10 +28,11 @@ public sealed class RtpJitterBufferPool : IDisposable
     /// <summary>Fired just before a stale source is removed.</summary>
     public event Action<uint>? SourceExpired;
 
-    public RtpJitterBufferPool(ILoggerFactory loggerFactory, int initialBufferMs)
+    public RtpJitterBufferPool(ILoggerFactory loggerFactory, bool opusEnabled, int initialBufferMs)
     {
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<RtpJitterBufferPool>();
+        _opusEnabled = opusEnabled;
         _initialBufferMs = initialBufferMs;
     }
 
@@ -43,7 +45,7 @@ public sealed class RtpJitterBufferPool : IDisposable
         var context = _sources.GetOrAdd(packet.Ssrc, ssrc =>
         {
             _logger.LogInformation("New RTP source: SSRC={Ssrc:X8}", ssrc);
-            var ctx = new RtpSourceContext(ssrc, _loggerFactory, _initialBufferMs);
+            var ctx = new RtpSourceContext(ssrc, _loggerFactory, _opusEnabled, _initialBufferMs);
             SourceAdded?.Invoke(ssrc);
             return ctx;
         });

--- a/OpenFreq.Common/RTPJitterBufferPool.cs
+++ b/OpenFreq.Common/RTPJitterBufferPool.cs
@@ -12,7 +12,6 @@ public sealed class RtpJitterBufferPool : IDisposable
 {
     private readonly ILogger<RtpJitterBufferPool> _logger;
     private readonly ILoggerFactory _loggerFactory;
-    private readonly bool _opusEnabled;
     private readonly int _initialBufferMs;
 
     private readonly ConcurrentDictionary<uint, RtpSourceContext> _sources = new();
@@ -28,11 +27,10 @@ public sealed class RtpJitterBufferPool : IDisposable
     /// <summary>Fired just before a stale source is removed.</summary>
     public event Action<uint>? SourceExpired;
 
-    public RtpJitterBufferPool(ILoggerFactory loggerFactory, bool opusEnabled, int initialBufferMs)
+    public RtpJitterBufferPool(ILoggerFactory loggerFactory, int initialBufferMs)
     {
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<RtpJitterBufferPool>();
-        _opusEnabled = opusEnabled;
         _initialBufferMs = initialBufferMs;
     }
 
@@ -45,7 +43,7 @@ public sealed class RtpJitterBufferPool : IDisposable
         var context = _sources.GetOrAdd(packet.Ssrc, ssrc =>
         {
             _logger.LogInformation("New RTP source: SSRC={Ssrc:X8}", ssrc);
-            var ctx = new RtpSourceContext(ssrc, _loggerFactory, _opusEnabled, _initialBufferMs);
+            var ctx = new RtpSourceContext(ssrc, _loggerFactory, _initialBufferMs);
             SourceAdded?.Invoke(ssrc);
             return ctx;
         });

--- a/OpenFreq.Common/RTPJitterbuffer.cs
+++ b/OpenFreq.Common/RTPJitterbuffer.cs
@@ -37,7 +37,7 @@ public class RtpJitterBuffer
     // Adaptive jitter buffer parameters
     private double _targetBufferMs = 60; // Start with 60ms
     private double _measuredJitterMs;
-    private const double MIN_BUFFER_MS = 30;
+    private const double MIN_BUFFER_MS = 20;
     private const double MAX_BUFFER_MS = 500;
         
     // Statistics

--- a/OpenFreq.Common/RTPPacket.cs
+++ b/OpenFreq.Common/RTPPacket.cs
@@ -17,7 +17,7 @@ public class RtpPacket
     public byte[]? ExtensionData { get; set; }
 
     // Payload (pure audio data)
-    public byte[] Payload { get; set; } = Array.Empty<byte>();
+    public byte[] Payload { get; set; } = [];
 
     public const int HEADER_SIZE = 12;
     public const ushort OpenFreqProfile = 0x4F46; // "OF" - OpenFreq

--- a/OpenFreq.Common/RtpSourceContext.cs
+++ b/OpenFreq.Common/RtpSourceContext.cs
@@ -27,7 +27,7 @@ public sealed class RtpSourceContext : IDisposable
     // Used by the pool to prune sources that have gone silent
     public long LastActivityTicks { get; set; }
 
-    public RtpSourceContext(uint ssrc, ILoggerFactory loggerFactory, int initialBufferMs)
+    public RtpSourceContext(uint ssrc, ILoggerFactory loggerFactory, bool opusEnabled, int initialBufferMs)
     {
         Ssrc = ssrc;
         LastActivityTicks = Stopwatch.GetTimestamp();

--- a/OpenFreq.Common/RtpSourceContext.cs
+++ b/OpenFreq.Common/RtpSourceContext.cs
@@ -15,7 +15,7 @@ public sealed class RtpSourceContext : IDisposable
     public uint Ssrc { get; }
     
     public RtpJitterBuffer JitterBuffer { get; }
-    public OpusDecoder? OpusDecoder { get; }
+    public OpusDecoder OpusDecoder { get; }
     
     // Loss detection state
     public ushort LastSequenceReceived { get; set; }
@@ -27,7 +27,7 @@ public sealed class RtpSourceContext : IDisposable
     // Used by the pool to prune sources that have gone silent
     public long LastActivityTicks { get; set; }
 
-    public RtpSourceContext(uint ssrc, ILoggerFactory loggerFactory, bool opusEnabled, int initialBufferMs)
+    public RtpSourceContext(uint ssrc, ILoggerFactory loggerFactory, int initialBufferMs)
     {
         Ssrc = ssrc;
         LastActivityTicks = Stopwatch.GetTimestamp();
@@ -35,12 +35,9 @@ public sealed class RtpSourceContext : IDisposable
         JitterBuffer = new RtpJitterBuffer(loggerFactory.CreateLogger<RtpJitterBuffer>());
         JitterBuffer.SetTargetBufferSize(initialBufferMs);
 
-        if (opusEnabled)
-        {
-            #pragma warning disable CS0618 // Using the new factory method will not work on Linux
-            OpusDecoder = new OpusDecoder(OpenFreqRtcClient.SAMPLE_RATE, OpenFreqRtcClient.CHANNELS);
-            #pragma warning restore CS0618
-        }
+        #pragma warning disable CS0618 // Using the new factory method will not work on Linux
+        OpusDecoder = new OpusDecoder(OpenFreqRtcClient.SAMPLE_RATE, 1);
+        #pragma warning restore CS0618
     }
 
     public void Dispose()

--- a/OpenFreq.Testclient/TestClient.cs
+++ b/OpenFreq.Testclient/TestClient.cs
@@ -121,11 +121,6 @@ public class TestClient
 
 public class TestClientWrapper : IDisposable
 {
-    const int CHANNELS = 1;
-    
-    private readonly Queue<byte> _audioBuffer = new();
-    private readonly int OPUS_FRAME_BYTES = 1920;
-
     private readonly OpenFreqRtcClient _client;
     private readonly List<int> _frequencies;
     private readonly Dictionary<int, bool> _isTransmitting = new();
@@ -176,7 +171,7 @@ public class TestClientWrapper : IDisposable
         }
 
         // Initialize playback stream
-        _playbackStream = Bass.CreateStream(OpenFreqRtcClient.SAMPLE_RATE, CHANNELS, BassFlags.Default, StreamProcedureType.Push);
+        _playbackStream = Bass.CreateStream(OpenFreqRtcClient.SAMPLE_RATE, 1, BassFlags.Default, StreamProcedureType.Push);
         if (_playbackStream == 0)
         {
             throw new Exception($"Failed to create playback stream: {Bass.LastError}");
@@ -246,7 +241,7 @@ public class TestClientWrapper : IDisposable
         Bass.CurrentRecordingDevice = 0;
 
         // Start recording with callback that sends via client
-        _recordHandle = Bass.RecordStart(OpenFreqRtcClient.SAMPLE_RATE, CHANNELS, BassFlags.RecordPause, RecordProcedure);
+        _recordHandle = Bass.RecordStart(OpenFreqRtcClient.SAMPLE_RATE, 1, BassFlags.RecordPause, RecordProcedure);
         if (_recordHandle == 0)
         {
             Console.WriteLine($"Failed to start recording: {Bass.LastError}");
@@ -293,41 +288,16 @@ public class TestClientWrapper : IDisposable
         if (!anyTransmitting)
             return true;
 
-        try
+        // Copy audio data to managed array
+        short[] audioData = new short[length / 2];
+        Marshal.Copy(buffer, audioData, 0, audioData.Length);
+        // Send complete frame to all transmitting frequencies
+        var transmitData = new List<(int frequencyKhz, double txPowerWatts, double ppm, Vector3? position, Vector3? velocity, AmbientNoiseType ambientNoiseType)>();
+        foreach (var frequency in _isTransmitting.Keys)
         {
-            // Copy audio data to managed array
-            byte[] audioData = new byte[length];
-            Marshal.Copy(buffer, audioData, 0, length);
-
-            // Add to buffer
-            foreach (byte b in audioData)
-            {
-                _audioBuffer.Enqueue(b);
-            }
-
-            // Process complete frames
-            while (_audioBuffer.Count >= OPUS_FRAME_BYTES)
-            {
-                // Extract exactly one frame
-                byte[] frameData = new byte[OPUS_FRAME_BYTES];
-                for (int i = 0; i < OPUS_FRAME_BYTES; i++)
-                {
-                    frameData[i] = _audioBuffer.Dequeue();
-                }
-
-                // Send complete frame to all transmitting frequencies
-                var transmitData = new List<(int frequencyKhz, double txPowerWatts, double ppm, Vector3? position, Vector3? velocity, AmbientNoiseType ambientNoiseType)>();
-                foreach (var frequency in _isTransmitting.Keys)
-                {
-                    transmitData.Add((frequency, 50, 0, new Vector3(), null, AmbientNoiseType.None));
-                }
-                _client.SendAudio(frameData, transmitData, false);
-            }
+            transmitData.Add((frequency, 50, 0, new Vector3(), null, AmbientNoiseType.None));
         }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error sending audio: {ex.Message}");
-        }
+        _client.SendAudio(audioData, transmitData, false);
 
         return true;
     }


### PR DESCRIPTION
- Run the recording callback as rapidly as possible (every 5ms, according to BASS docs) to shovel mic audio out the door with minimal delay.

- Remove the "pacing timer" in the TX path and process samples as soon as we have enough of them.

- Remove at least 4 redundant copies in the TX path

- Reduce Opus bitrate to 24k (which the authors say is good enough for full-band mono).

Some additional simplifications:

- Assume we're always transmitting mono. (There's no world where we'd want stereo (quadraphonic? :P ) TXes

- Always use Opus - it's designed for low-latency, real-time audio, and handles packet loss much more gracefully.

Pairs with https://github.com/UOAF/OpenFreqAudio/pull/10
Drives latency down from ~120ms to ~50-80 ms on my machine.