### PR TITLE
Fixes double key capture

### DIFF
--- a/OpenFreq.Client/OpenFreq.Client.csproj
+++ b/OpenFreq.Client/OpenFreq.Client.csproj
@@ -47,7 +47,7 @@
         <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-        <PackageReference Include="SharpHook" Version="7.0.3" />
+        <PackageReference Include="SharpHook" Version="7.1.1" />
         <PackageReference Include="SkiaSharp.Svg" Version="1.60.0" />
     </ItemGroup>
 

--- a/OpenFreq.Client/Services/HotkeyService.cs
+++ b/OpenFreq.Client/Services/HotkeyService.cs
@@ -10,12 +10,9 @@ namespace OpenFreqClient.Services;
 
 public class HotkeyService : IHotkeyService
 {
-    
-    
     private TaskPoolGlobalHook? _hook;
     private CancellationTokenSource? _cts;
     private Task? _hookTask;
-    private bool _pttPaused;
 
     private readonly Dictionary<KeyCode, List<Guid>> _pttBindings = new();
     private readonly Dictionary<KeyCode, List<Guid>> _squelchToggleBindings = new();
@@ -71,13 +68,15 @@ public class HotkeyService : IHotkeyService
 
     public void PausePttKeys()
     { 
-        _pttPaused = true;
+        PttKeysPaused = true;
     }
 
     public void ResumePttKeys()
     {
-        _pttPaused = false;
+        PttKeysPaused = false;
     }
+
+    public bool PttKeysPaused { get; private set; }
 
     public void RegisterHotkey(IHotkeyService.HotkeyType type, KeyCode key, Guid channelId)
     {
@@ -176,7 +175,7 @@ public class HotkeyService : IHotkeyService
         // We allow for arbitrary double binds, so just fire every valid event
         if (_pttBindings.TryGetValue(e.Data.KeyCode, out var pttBindingsList))
         {
-            if (!_pttPaused)
+            if (!PttKeysPaused)
                 HotkeyPressed?.Invoke(this, new HotkeyPressedEventArgs(IHotkeyService.HotkeyType.Ptt, pttBindingsList));
         }
         
@@ -192,7 +191,7 @@ public class HotkeyService : IHotkeyService
 
         if (_pttBindings.TryGetValue(e.Data.KeyCode, out var pttBinding))
         {
-            if (!_pttPaused)
+            if (!PttKeysPaused)
              HotkeyReleased?.Invoke(this, new HotkeyReleasedEventArgs(IHotkeyService.HotkeyType.Ptt, pttBinding));
         }
 

--- a/OpenFreq.Client/Services/Interfaces/IHotkeyService.cs
+++ b/OpenFreq.Client/Services/Interfaces/IHotkeyService.cs
@@ -18,6 +18,8 @@ public interface IHotkeyService : IDisposable, ILifecycleService
     void PausePttKeys();
     void ResumePttKeys();
     
+    bool PttKeysPaused { get; }
+    
     // Binding management
     void RegisterHotkey(HotkeyType type, KeyCode key, Guid channelId);
     void UnregisterHotkey(HotkeyType type, KeyCode key, Guid channelId);

--- a/OpenFreq.Client/ViewModels/ChannelCardListViewModel.cs
+++ b/OpenFreq.Client/ViewModels/ChannelCardListViewModel.cs
@@ -290,6 +290,10 @@ public partial class ChannelCardListViewModel : ViewModelBase, IDisposable
 
     private void OnBmsPttChanged(object? sender, RadioPttChangedEventArgs e)
     {
+        // Do NOT capture keys twice - for non-flying, we want to use the callbacks from our HotKey service
+        if (!_hotkeyService.PttKeysPaused ||_falconSharedMemoryService.IsFlying == false)
+            return;
+        
         if (FalconChannelGroup == null)
         {
             _logger.LogWarning("Ignoring PTT: no Falcon channel group");


### PR DESCRIPTION
Eliminates double key captures (both our hooks AND the bms hooks). This leads to constant tx toggles and unwanted voice distortions