### PR TITLE
Comms Cleanup

### DIFF
--- a/OpenFreq.Client/Services/OpenFreqService.cs
+++ b/OpenFreq.Client/Services/OpenFreqService.cs
@@ -424,7 +424,7 @@ public class OpenFreqService : IOpenFreqService
                 OnStatusMessage($"Failed to start recording: {Bass.LastError}");
                 return;
             }
-
+            _client.MarkTransmitStartTime();
             Bass.ChannelPlay(_recordHandle);
         }
 

--- a/OpenFreq.Common/AudioPacketMetadata.cs
+++ b/OpenFreq.Common/AudioPacketMetadata.cs
@@ -27,9 +27,6 @@ public class AudioPacketMetadata
     
     [JsonPropertyName("server_send_timestamp")]
     public long ServerSendTimestamp { get; set; }
-    
-    [JsonIgnore]
-    public bool HasAnyBeginMarker => Frequencies.Any(f => f.BeginMarker);
 }
 
 // Vector data structure

--- a/OpenFreq.Common/FrequencyTransmission.cs
+++ b/OpenFreq.Common/FrequencyTransmission.cs
@@ -15,18 +15,6 @@ public class FrequencyTransmission
     public int Khz { get; set; }
     [JsonPropertyName("txpower")]
     public double TxPowerWatts { get; set; }
-    
-    /// <summary>
-    /// True if this is the first packet of a transmission on this frequency
-    /// </summary>
-    [JsonPropertyName("begin")]
-    public bool BeginMarker { get; set; }
-    
-    /// <summary>
-    /// True if this is the last packet of a transmission on this frequency
-    /// </summary>
-    [JsonPropertyName("end")]
-    public bool EndMarker { get; set; }
 
     [JsonPropertyName("position")]
     public Vector3? Position { get; set; }
@@ -47,25 +35,15 @@ public class FrequencyTransmission
     {
     }
 
-    public FrequencyTransmission(int khz, double txPowerWatts, double ppm, Vector3? position, Vector3? velocity, bool in3d, bool beginMarker = false,
-        bool endMarker = false, AmbientNoiseType ambientNoiseType = AmbientNoiseType.None)
+    public FrequencyTransmission(int khz, double txPowerWatts, double ppm, Vector3? position, Vector3? velocity, bool in3d,
+        AmbientNoiseType ambientNoiseType = AmbientNoiseType.None)
     {
         Khz = khz;
         TxPowerWatts = txPowerWatts;
         Ppm = ppm;
-        BeginMarker = beginMarker;
-        EndMarker = endMarker;
         Position = position;
         Velocity = velocity;
         In3d = in3d;
         AmbientNoiseType = ambientNoiseType;
-    }
-
-    public override string ToString()
-    {
-        var markers = "";
-        if (BeginMarker) markers += "BEGIN ";
-        if (EndMarker) markers += "END ";
-        return $"{Khz/1000d:F3} MHz {(markers.Length > 0 ? $"[{markers.Trim()}]" : "")}";
     }
 }

--- a/OpenFreq.Common/OpenFreqRtcClient.cs
+++ b/OpenFreq.Common/OpenFreqRtcClient.cs
@@ -44,7 +44,6 @@ public class OpenFreqRtcClient : IDisposable
 
     // Transmission state
     private readonly Dictionary<int, bool> _frequencyTransmissionState = new();
-    private readonly Dictionary<int, bool> _frequencyFirstPacketSent = new();
     private readonly Dictionary<int, HashSet<string>> _frequencyPeers = new();
 
     private readonly ILogger<OpenFreqRtcClient> _logger;
@@ -196,7 +195,6 @@ public class OpenFreqRtcClient : IDisposable
 
         _frequencyPeers.Remove(frequencyKhz);
         _frequencyTransmissionState.Remove(frequencyKhz);
-        _frequencyFirstPacketSent.Remove(frequencyKhz); // Clean up tracking state
         OnFrequencyLeft(frequencyKhz);
     }
 
@@ -216,7 +214,6 @@ public class OpenFreqRtcClient : IDisposable
         }
 
         _frequencyTransmissionState[frequencyKhz] = true;
-        _frequencyFirstPacketSent[frequencyKhz] = false; // Mark that we need to send startMarker
 
         await SendMessageAsync(SignalingMessageFactory.CreateTransmission(frequencyKhz, true, is3d));
         OnTransmissionStateChanged(frequencyKhz, true);
@@ -240,18 +237,7 @@ public class OpenFreqRtcClient : IDisposable
             return;
         }
 
-        // Send final silent packet with endMarker
-        var silence = new short[OPUS_SAMPLES_PER_FRAME]; // 20ms silence, 16-bit PCM
-        
-        _rtpSender?.SendAudio(
-            audioData: silence,
-            frequencyTransmissions: [new FrequencyTransmission(frequencyKhz, 0, 0, new Vector3(), null, false, true)]
-        );
-
-        _logger.LogInformation("Sent end marker for frequency {Frequency:F3}", frequencyKhz / 1000d);
-
         _frequencyTransmissionState[frequencyKhz] = false;
-        _frequencyFirstPacketSent.Remove(frequencyKhz); // Clean up tracking state
 
         await SendMessageAsync(SignalingMessageFactory.CreateTransmission(frequencyKhz, false, is3d));
         OnTransmissionStateChanged(frequencyKhz, false);
@@ -275,7 +261,6 @@ public class OpenFreqRtcClient : IDisposable
         var frequencyTransmissions = new List<FrequencyTransmission>();
         foreach (var freq in frequencies)
         {
-            bool needsBeginMarker = _frequencyFirstPacketSent.TryGetValue(freq.frequencyKhz, out var sent) && !sent;
             frequencyTransmissions.Add(new FrequencyTransmission(
                 khz: freq.frequencyKhz,
                 txPowerWatts: freq.txPowerWatts,
@@ -283,13 +268,8 @@ public class OpenFreqRtcClient : IDisposable
                 position: freq.position,
                 velocity: freq.velocity,
                 ambientNoiseType: freq.ambientNoiseType,
-                in3d: in3d,
-                beginMarker: needsBeginMarker,
-                endMarker: false
+                in3d: in3d
             ));
-
-            if (needsBeginMarker)
-                _frequencyFirstPacketSent[freq.frequencyKhz] = true;
         }
         
         _rtpSender?.SendAudio(pcmData, frequencyTransmissions);

--- a/OpenFreq.Common/OpenFreqRtcClient.cs
+++ b/OpenFreq.Common/OpenFreqRtcClient.cs
@@ -528,7 +528,7 @@ public class OpenFreqRtcClient : IDisposable
         PeerTransmissionStateChanged?.Invoke(this,
             new PeerTransmissionEventArgs(peerId, peerDisplayName, frequencyKhz, isTransmitting, is3d));
 
-    private void OnAudioDataReceived(string peerId, byte[] audioData, AudioPacketMetadata metadata) =>
+    private void OnAudioDataReceived(string peerId, Memory<short> audioData, AudioPacketMetadata metadata) =>
         AudioDataReceived?.Invoke(this, new AudioDataEventArgs(peerId, audioData, metadata));
 
     private void OnAllPeersStatusReceived(Dictionary<int, List<PeerData>> allPeersStatus) =>
@@ -643,10 +643,10 @@ public class PeerTransmissionEventArgs : EventArgs
 public class AudioDataEventArgs : EventArgs
 {
     public string PeerId { get; }
-    public byte[] AudioData { get; }
+    public Memory<short> AudioData { get; }
     public AudioPacketMetadata Metadata { get; }
 
-    public AudioDataEventArgs(string peerId, byte[] audioData, AudioPacketMetadata metadata)
+    public AudioDataEventArgs(string peerId, Memory<short> audioData, AudioPacketMetadata metadata)
     {
         PeerId = peerId;
         AudioData = audioData;

--- a/OpenFreq.Common/OpenFreqRtcClient.cs
+++ b/OpenFreq.Common/OpenFreqRtcClient.cs
@@ -255,7 +255,13 @@ public class OpenFreqRtcClient : IDisposable
         
         await SendMessageAsync(SignalingMessageFactory.CreateSetDisplayName(displayName));
     }
-    
+
+    /// <see cref="RtpAudioSender.MarkTransmitStartTime"/>
+    public void MarkTransmitStartTime()
+    {
+        _rtpSender!.MarkTransmitStartTime();
+    }
+
     public void SendAudio(Memory<short> pcmData, List<(int frequencyKhz, double txPowerWatts, double ppm, Vector3? position, Vector3? velocity, AmbientNoiseType ambientNoiseType)> frequencies, bool in3d)
     {
         var frequencyTransmissions = new List<FrequencyTransmission>();

--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -290,9 +290,7 @@ public class RtpAudioReceiver : IDisposable
                         position: freq.Position,
                         velocity: freq.Velocity,
                         in3d: freq.In3d,
-                        ambientNoiseType: freq.AmbientNoiseType,
-                        beginMarker: false,
-                        endMarker: false
+                        ambientNoiseType: freq.AmbientNoiseType
                     ));
                 }
             }

--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -1,10 +1,11 @@
-﻿using System.Net;
-using System.Net.Sockets;
-using System.Text;
-using System.Text.Json;
-using Concentus.Structs;
+﻿using Concentus.Structs;
 using Microsoft.Extensions.Logging;
 using OpenFreq.Common.Rtp;
+using System.Net;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
 
 // This is to avoid issues in Linux where the Concentus Factory methods does not work currently.
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -20,7 +21,7 @@ public class RtpAudioReceiver : IDisposable
 {
     public class AudioReceivedEventArgs : EventArgs
     {
-        public byte[] AudioData { get; set; } = Array.Empty<byte>();
+        public Memory<short> AudioData { get; set; }
         public required AudioPacketMetadata Metadata { get; set; }
     }
 
@@ -33,10 +34,6 @@ public class RtpAudioReceiver : IDisposable
     private readonly bool _opusEnabled;
     private readonly CancellationTokenSource _cts = new();
     private readonly Timer _playoutTimer;
-
-    // FEC statistics (aggregate across all sources)
-    private int _fecRecoveries;
-    private int _plcRecoveries;
 
     // Prune stale sources every N ticks (20ms * 50 = 1s)
     private int _pruneCountdown = 50;
@@ -185,8 +182,8 @@ public class RtpAudioReceiver : IDisposable
                                 for (int i = 0; i < gap; i++)
                                 {
                                     ushort lostSeq = (ushort)(expectedSeq + i);
-                                    // Only the first lost packet can use FEC (next packet carries FEC for it)
-                                    GenerateConcealmentAudio(lostSeq, i == 0 ? packet : null, context);
+                                    // Only the last lost packet can use FEC (next packet carries FEC for it)
+                                    GenerateConcealmentAudio(lostSeq, i == gap - 1 ? packet : null, context);
                                 }
                             }
                         }
@@ -231,16 +228,18 @@ public class RtpAudioReceiver : IDisposable
 
             context.LastValidMetadata = metadata;
 
-            byte[] decodedAudio;
+            Memory<short> decodedAudio;
             if (_opusEnabled && context.OpusDecoder != null)
             {
-                decodedAudio = DecodeOpus(packet.Payload, context.OpusDecoder, isLost: false, decodeFec: false);
+                decodedAudio = DecodeOpus(packet.Payload, context.OpusDecoder, decodeFec: false);
                 if (decodedAudio.Length == 0)
                     return;
             }
             else
             {
-                decodedAudio = packet.Payload;
+                var buf = new short[packet.Payload.Length / 2];
+                decodedAudio = new Memory<short>(buf);
+                packet.Payload.CopyTo(MemoryMarshal.AsBytes(decodedAudio.Span));
             }
 
             #if DEBUG
@@ -266,50 +265,15 @@ public class RtpAudioReceiver : IDisposable
     {
         try
         {
-            byte[] concealmentAudio;
-            bool usedFec = false;
+            Memory<short> concealmentAudio;
 
-            if (nextPacket != null)
-            {
-                var nextOpusData = ExtractOpusDataFromPacket(nextPacket);
+            byte[] nextOpusData = nextPacket?.Payload ?? [];
 
-                _logger.LogDebug(
-                    "SSRC={Ssrc:X8}: loss recovery for seq {LostSeq}: nextPacket seq {NextSeq}, {Bytes} bytes",
-                    context.Ssrc, lostSequence, nextPacket.SequenceNumber, nextOpusData?.Length ?? 0);
+            _logger.LogDebug(
+                "SSRC={Ssrc:X8}: loss recovery for seq {LostSeq}: {Bytes} bytes",
+                context.Ssrc, lostSequence, nextOpusData.Length);
 
-                if (nextOpusData is { Length: > 0 })
-                {
-                    concealmentAudio = DecodeOpus(nextOpusData, context.OpusDecoder, isLost: false, decodeFec: true);
-
-                    if (concealmentAudio.Length > 0)
-                    {
-                        usedFec = true;
-                        Interlocked.Increment(ref _fecRecoveries);
-                        _logger.LogInformation(
-                            "SSRC={Ssrc:X8}: ✓ FEC recovered seq {LostSeq} from seq {NextSeq} ({Bytes} bytes)",
-                            context.Ssrc, lostSequence, nextPacket.SequenceNumber, concealmentAudio.Length);
-                    }
-                    else
-                    {
-                        _logger.LogDebug("SSRC={Ssrc:X8}: FEC returned 0 bytes, falling back to PLC", context.Ssrc);
-                        concealmentAudio = DecodeOpus([], context.OpusDecoder, isLost: true);
-                        Interlocked.Increment(ref _plcRecoveries);
-                    }
-                }
-                else
-                {
-                    _logger.LogDebug("SSRC={Ssrc:X8}: could not extract Opus data, using PLC", context.Ssrc);
-                    concealmentAudio = DecodeOpus([], context.OpusDecoder, isLost: true);
-                    Interlocked.Increment(ref _plcRecoveries);
-                }
-            }
-            else
-            {
-                _logger.LogDebug("SSRC={Ssrc:X8}: no nextPacket for seq {LostSeq}, using PLC", context.Ssrc,
-                    lostSequence);
-                concealmentAudio = DecodeOpus([], context.OpusDecoder, isLost: true);
-                Interlocked.Increment(ref _plcRecoveries);
-            }
+            concealmentAudio = DecodeOpus(nextOpusData, context.OpusDecoder, decodeFec: nextPacket != null);
 
             if (concealmentAudio.Length == 0)
                 return;
@@ -335,7 +299,7 @@ public class RtpAudioReceiver : IDisposable
 
             var metadata = new AudioPacketMetadata
             {
-                ClientId = context.LastValidMetadata?.ClientId ?? (usedFec ? "FEC" : "PLC"),
+                ClientId = context.LastValidMetadata?.ClientId ?? "Recovered",
                 Frequencies = frequencies
             };
 
@@ -355,62 +319,34 @@ public class RtpAudioReceiver : IDisposable
     /// <summary>
     /// Decode Opus audio using the provided decoder instance (one per SSRC).
     /// </summary>
-    private byte[] DecodeOpus(byte[] opusData, OpusDecoder decoder, bool isLost = false, bool decodeFec = false)
+    private Memory<short> DecodeOpus(ReadOnlySpan<byte> opusData, OpusDecoder decoder, bool decodeFec)
     {
         try
         {
-            const int maxOpusFrameSamples = 5760; // 120ms at 48kHz
-            short[] pcmSamples = new short[maxOpusFrameSamples];
+            short[] pcmSamples = new short[OPUS_FRAME_SAMPLES];
+            var outSpan = new Memory<short>(pcmSamples);
 
-            int? samplesDecoded;
+            int samplesDecoded;
 
-            if (isLost)
+            // We're actually looking for the _previous_ packet,
+            // which can be FEC'd into the next in case it gets lost.
+            samplesDecoded = decoder.Decode(
+                opusData, outSpan.Span, OPUS_FRAME_SAMPLES, decodeFec);
+
+            if (samplesDecoded <= 0)
             {
-                samplesDecoded = decoder.Decode(
-                    Array.Empty<byte>(), 0, 0,
-                    pcmSamples, 0, OPUS_FRAME_SAMPLES);
-
-                if (samplesDecoded > 0)
-                    _logger.LogDebug("Generated PLC audio: {Samples} samples", samplesDecoded);
+                _logger.LogWarning("Opus decode failed for {ByteCount} bytes (decodeFec={DecodeFec})",
+                    opusData.Length, decodeFec);
+                return Memory<short>.Empty;
             }
-            else if (decodeFec)
-            {
-                samplesDecoded = decoder.Decode(
-                    opusData, 0, opusData.Length,
-                    pcmSamples, 0, OPUS_FRAME_SAMPLES,
-                    true);
-
-                if (samplesDecoded > 0)
-                    _logger.LogDebug("FEC decode: {Samples} samples from {Bytes} bytes", samplesDecoded,
-                        opusData.Length);
-            }
-            else
-            {
-                samplesDecoded = decoder.Decode(
-                    opusData, 0, opusData.Length,
-                    pcmSamples, 0, maxOpusFrameSamples);
-            }
-
-            if (samplesDecoded is null or <= 0)
-            {
-                _logger.LogWarning("Opus decode failed for {ByteCount} bytes (isLost={IsLost}, decodeFec={DecodeFec})",
-                    opusData.Length, isLost, decodeFec);
-                return [];
-            }
-
-            var decodedAudio = new byte[samplesDecoded.Value * 2];
-            Buffer.BlockCopy(pcmSamples, 0, decodedAudio, 0, decodedAudio.Length);
-            return decodedAudio;
+            return outSpan[..samplesDecoded];
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Opus decode exception (isLost={IsLost}, decodeFec={DecodeFec})", isLost, decodeFec);
-            return [];
+            _logger.LogError(ex, "Opus decode exception (decodeFec={DecodeFec})", decodeFec);
+            return Memory<short>.Empty;
         }
     }
-
-    private static byte[]? ExtractOpusDataFromPacket(RtpPacket packet)
-        => packet.Payload.Length > 0 ? packet.Payload : null;
 
     public (int received, int lost, int late, int duplicate, int played,
         double lossPercent, double jitterMs, double bufferMs, int buffered) GetStatistics()
@@ -426,14 +362,6 @@ public class RtpAudioReceiver : IDisposable
         _logger.LogInformation("  Packets duplicate: {Duplicate}", stats.duplicate);
         _logger.LogInformation("  Packets played: {Played}", stats.played);
         _logger.LogInformation("  Loss Recovery:");
-        _logger.LogInformation("    FEC recoveries: {FecCount}", _fecRecoveries);
-        _logger.LogInformation("    PLC recoveries: {PlcCount}", _plcRecoveries);
-
-        if (_fecRecoveries + _plcRecoveries > 0)
-        {
-            var fecPercent = 100.0 * _fecRecoveries / (_fecRecoveries + _plcRecoveries);
-            _logger.LogInformation("    FEC success rate: {FecRate:F1}%", fecPercent);
-        }
 
         _logger.LogInformation("  Measured jitter: {JitterMs:F1}ms (avg)", stats.jitterMs);
         _logger.LogInformation("  Buffer size: {BufferMs:F0}ms (avg, adaptive)", stats.bufferMs);

--- a/OpenFreq.Common/RTPAudioSender.cs
+++ b/OpenFreq.Common/RTPAudioSender.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
@@ -36,6 +36,7 @@ public class RtpAudioSender : IDisposable
 #pragma warning restore CS0618 // Type or member is obsolete
 
     // RTP state
+    private volatile uint _timestamp = 0;
     private volatile List<FrequencyTransmission> _frequencies = [];
     private readonly uint _ssrc;
     private readonly string _clientId;
@@ -103,6 +104,21 @@ public class RtpAudioSender : IDisposable
         _logger.LogInformation("  SSRC: 0x{Ssrc:X8}", _ssrc);
     }
 
+    /// <summary>
+    /// Call on the start of a new transmission to clear any stale samples
+    /// and to ensure packet timestamps reflect the gap.
+    /// </summary>
+    public void MarkTransmitStartTime()
+    {
+        _sendQueue.Clear();
+        var now = Stopwatch.GetTimestamp();
+        var dt = now - _startTimeTicks;
+        // Loses some precision for large dt - if timestamps are wonky,
+        // consider (double)((decimal)dt / Stopwatch.Frequency)
+        double dtSeconds = (double)dt / Stopwatch.Frequency;
+        double dtSamples = dtSeconds * OpenFreqRtcClient.SAMPLE_RATE;
+        _timestamp = (uint)(dtSamples % uint.MaxValue);
+    }
 
     /// <summary>
     /// Send audio packet with metadata
@@ -120,7 +136,6 @@ public class RtpAudioSender : IDisposable
 
     private void SendThreadProc()
     {
-        uint timestamp = 0;
         ushort sequence = 0;
         var drainbuf = new short[OPUS_FRAME_SIZE];
         var encoded = new byte[OPUS_FRAME_SIZE * 2];
@@ -130,7 +145,6 @@ public class RtpAudioSender : IDisposable
         {
             var dspan = new Memory<short>(drainbuf);
             if (!_sendQueue.DrainExactly(dspan.Span)) return;
-            ushort nextSequence = (ushort)(sequence + dspan.Length);
 
             // Encode audio (happens here, not in audio callback)
             encspan = new Memory<byte>(encoded);
@@ -164,7 +178,7 @@ public class RtpAudioSender : IDisposable
                 Version = 2,
                 PayloadType = _opusEnabled ? PAYLOAD_TYPE_OPUS : PAYLOAD_TYPE_PCMU,
                 SequenceNumber = sequence,
-                Timestamp = timestamp,
+                Timestamp = _timestamp,
                 Ssrc = _ssrc,
                 ExtensionProfile = RtpPacket.OpenFreqProfile,
                 ExtensionData = metadataBytes,
@@ -174,7 +188,8 @@ public class RtpAudioSender : IDisposable
             // Send the packet
             var rtpBytes = rtpPacket.ToBytes();
             _udpClient.Send(rtpBytes, rtpBytes.Length, _serverEndpoint);
-            sequence = nextSequence;
+            _timestamp += OPUS_FRAME_SIZE;
+            sequence++;
         }
     }
 

--- a/OpenFreq.Common/RTPJitterbuffer.cs
+++ b/OpenFreq.Common/RTPJitterbuffer.cs
@@ -16,7 +16,6 @@ public class RtpJitterBuffer
     {
         public required RtpPacket Packet { get; set; }
         public long ReceivedTicks { get; set; }
-        public uint PlayoutTimestamp { get; set; }
     }
         
     private readonly SortedDictionary<ushort, BufferedPacket> _buffer = new();
@@ -91,8 +90,7 @@ public class RtpJitterBuffer
             var bufferedPacket = new BufferedPacket
             {
                 Packet = packet,
-                ReceivedTicks = Stopwatch.GetTimestamp(),
-                PlayoutTimestamp = packet.Timestamp
+                ReceivedTicks = Stopwatch.GetTimestamp()
             };
 
             // Add to buffer
@@ -138,7 +136,7 @@ public class RtpJitterBuffer
 
             // Find packets ready for playout
             var readyPackets = _buffer
-                .Where(kvp => RtpPacket.TimestampDifference(playoutTimestamp, kvp.Value.PlayoutTimestamp) >= 0)
+                .Where(kvp => RtpPacket.TimestampDifference(playoutTimestamp, kvp.Value.Packet.Timestamp) >= 0)
                 .OrderBy(kvp => kvp.Key)
                 .ToList();
 
@@ -211,7 +209,7 @@ public class RtpJitterBuffer
         {
             // Find packets ready for playout
             var readyPackets = _buffer
-                .Where(kvp => RtpPacket.TimestampDifference(playoutTimestamp, kvp.Value.PlayoutTimestamp) >= 0)
+                .Where(kvp => RtpPacket.TimestampDifference(playoutTimestamp, kvp.Value.Packet.Timestamp) >= 0)
                 .OrderBy(kvp => kvp.Key)
                 .ToList();
 

--- a/OpenFreq.Common/RTPJitterbuffer.cs
+++ b/OpenFreq.Common/RTPJitterbuffer.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using OpenFreq.Common.Rtp;
 

--- a/OpenFreq.Common/RTPJitterbuffer.cs
+++ b/OpenFreq.Common/RTPJitterbuffer.cs
@@ -17,22 +17,32 @@ public class RtpJitterBuffer
         public required RtpPacket Packet { get; set; }
         public long ReceivedTicks { get; set; }
     }
-        
+    /// <summary>
+    /// Sorts packets based on their (extended) sequence number
+    /// </summary>
     private readonly SortedDictionary<ushort, BufferedPacket> _buffer = new();
     private readonly Queue<double> _jitterSamples = new(50);
-    private readonly int _sampleRate;
     private readonly int _maxBufferPackets;
         
-    // State
-    private ushort _nextExpectedSequence;
-    private bool _firstPacketPlayed; // true once _nextExpectedSequence has been seeded from real data
+    /// <summary>
+    /// Once we've played a packet, the next expected one. Used to detect missing ones.
+    /// </summary>
+    private ushort? _nextExpectedSequence;
+    /// <summary>
+    /// Starting (extended) timestamp from the first packet
+    /// </summary>
     private uint _baseTimestamp;
+    /// <summary>
+    /// Local monotonic time when the first packet arrived.
+    /// Jitter is a comparison to the base timestamp
+    /// </summary>
     private long _baseTimeTicks;
-    private long _playoutStartTicks;
+    /// <summary>
+    /// Local monotonic time when the last packet arrived.
+    /// </summary>
     private long _lastPacketReceivedTicks;
-    private double _lastPacketTimestamp;
-    private bool _initialized;
-        
+    private long _lastPacketTimestamp;
+
     // Adaptive jitter buffer parameters
     private double _targetBufferMs = 60; // Start with 60ms
     private double _measuredJitterMs;
@@ -49,7 +59,6 @@ public class RtpJitterBuffer
     public RtpJitterBuffer(ILogger<RtpJitterBuffer> logger, int sampleRate = OpenFreqRtcClient.SAMPLE_RATE, int maxBufferPackets = 200)
     {
         _logger = logger;
-        _sampleRate = sampleRate;
         _packetsLate = 0;
         _maxBufferPackets = maxBufferPackets;
     }
@@ -59,18 +68,16 @@ public class RtpJitterBuffer
     /// </summary>
     public void AddPacket(RtpPacket packet)
     {
-        _packetsReceived++;
     
         // Initialize on first packet
-        if (!_initialized)
+        if (_packetsReceived == 0)
         {
             _baseTimestamp = packet.Timestamp;
             _baseTimeTicks = Stopwatch.GetTimestamp();
-            _playoutStartTicks = _baseTimeTicks + (long)(_targetBufferMs / 1000.0 * Stopwatch.Frequency);
-            _initialized = true;
 
             _logger.LogInformation("Initialized: buffer={BufferMs}ms", _targetBufferMs);
         }
+        _packetsReceived++;
 
         lock (_buffer)
         {
@@ -85,7 +92,6 @@ public class RtpJitterBuffer
 
             // Calculate playout time
             long timestampDiff = RtpPacket.TimestampDifference(packet.Timestamp, _baseTimestamp);
-            double timestampMs = (timestampDiff * 1000.0) / _sampleRate;
 
             var bufferedPacket = new BufferedPacket
             {
@@ -96,7 +102,7 @@ public class RtpJitterBuffer
             // Add to buffer
             _buffer[packet.SequenceNumber] = bufferedPacket;
 
-            MeasureJitter(bufferedPacket, timestampMs);
+            MeasureJitter(bufferedPacket.ReceivedTicks, timestampDiff);
 
             // Adapt buffer size
             AdaptBufferSize();
@@ -116,18 +122,17 @@ public class RtpJitterBuffer
     /// </summary>
     public RtpPacket? GetNextPacket()
     {
-        if (!_initialized || _buffer.Count == 0)
+        if (_packetsReceived == 0 || _buffer.Count == 0)
             return null;
-        
+
         var nowTicks = Stopwatch.GetTimestamp();
+        var elapsedTicks = nowTicks - _baseTimeTicks;
 
-        if (nowTicks < _playoutStartTicks)
-            return null;
-
-        var elapsedTicks = nowTicks - _playoutStartTicks;
-
-        // Calculate which timestamp we should be playing now
-        uint playoutTimestamp = _baseTimestamp + (uint)((double)elapsedTicks * _sampleRate / Stopwatch.Frequency);
+        // The playout position is "where the sender was _targetBufferMs ago".
+        // When _targetBufferMs changes (via AdaptBufferSize), this adjusts immediately.
+        long elapsedSamples = (long)((double)elapsedTicks * OpenFreqRtcClient.SAMPLE_RATE / Stopwatch.Frequency);
+        long bufferDelaySamples = (long)(_targetBufferMs / 1000.0 * OpenFreqRtcClient.SAMPLE_RATE);
+        uint playoutTimestamp = _baseTimestamp + (uint)(elapsedSamples - bufferDelaySamples);
 
         KeyValuePair<ushort, BufferedPacket> nextPacket;
         lock (_buffer)
@@ -137,7 +142,6 @@ public class RtpJitterBuffer
             // Find packets ready for playout
             var readyPackets = _buffer
                 .Where(kvp => RtpPacket.TimestampDifference(playoutTimestamp, kvp.Value.Packet.Timestamp) >= 0)
-                .OrderBy(kvp => kvp.Key)
                 .ToList();
 
             if (readyPackets.Count == 0)
@@ -151,124 +155,66 @@ public class RtpJitterBuffer
 
             // Check if this is the expected sequence (loss detection).
             // Skip the check on the first packet
-            if (!_firstPacketPlayed)
+            if (_nextExpectedSequence.HasValue)
             {
-                _firstPacketPlayed = true;
-            }
-            else if (nextPacket.Key != _nextExpectedSequence)
-            {
-                var gap = RtpPacket.SequenceDifference(nextPacket.Key, _nextExpectedSequence);
+                var nextExpected = _nextExpectedSequence.Value;
+                var gap = RtpPacket.SequenceDifference(nextPacket.Key, nextExpected);
                 if (gap > 0)
                 {
                     // Skipped packets (loss)
                     _packetsLost += gap;
                     _logger.LogWarning("Packet loss: {Gap} packets (seq {ExpectedSeq} to {LastSeq})", 
-                        gap, _nextExpectedSequence, nextPacket.Key - 1);
+                        gap, nextExpected, nextPacket.Key - 1);
                 }
                 else
                 {
                     // Late packet
                     _packetsLate++;
                     _logger.LogWarning("Late packet seq {SequenceNumber} (expected {ExpectedSequence})", 
-                        nextPacket.Key, _nextExpectedSequence);
+                        nextPacket.Key, nextExpected);
                 }
             }
 
             _nextExpectedSequence = (ushort)(nextPacket.Key + 1);
             _packetsPlayed++;
 
-            // Steer the playout clock towards the target buffer depth
-            AdjustPlayoutClock();
         }
 
         return nextPacket.Value.Packet;
-    }
-    
-    /// <summary>
-    /// Peek at the next packet that would be returned, without removing it
-    /// Used for FEC decoding when checking if packet N+1 exists
-    /// </summary>
-    public RtpPacket? PeekNextPacket()
-    {
-        if (!_initialized || _buffer.Count == 0)
-            return null;
-        
-        var nowTicks = Stopwatch.GetTimestamp();
-
-        if (nowTicks < _playoutStartTicks)
-        {
-            return null;
-        }
-
-        var elapsedTicks = nowTicks - _playoutStartTicks;
-
-        // Calculate which timestamp we should be playing now
-        uint playoutTimestamp = _baseTimestamp + (uint)((double)elapsedTicks * _sampleRate / Stopwatch.Frequency);
-
-        lock (_buffer)
-        {
-            // Find packets ready for playout
-            var readyPackets = _buffer
-                .Where(kvp => RtpPacket.TimestampDifference(playoutTimestamp, kvp.Value.Packet.Timestamp) >= 0)
-                .OrderBy(kvp => kvp.Key)
-                .ToList();
-
-            if (readyPackets.Count == 0)
-            {
-                return null;
-            }
-
-            // Return the packet without removing it
-            return readyPackets.First().Value.Packet;
-        }
-    }
-    
-    /// <summary>
-    /// Try to get a specific packet by sequence number (for FEC)
-    /// </summary>
-    public RtpPacket? GetPacketBySequence(ushort sequenceNumber)
-    {
-        lock (_buffer)
-        {
-            if (_buffer.TryGetValue(sequenceNumber, out var bufferedPacket))
-            {
-                return bufferedPacket.Packet;
-            }
-            return null;
-        }
     }
         
     /// <summary>
     /// Measure packet arrival jitter
     /// </summary>
-    private void MeasureJitter(BufferedPacket packet, double expectedTimestampMs)
+    private void MeasureJitter(long ticksElapsed, long samplesElapsed)
     {
         if (_lastPacketReceivedTicks == 0)
         {
             // First packet - just record baseline
-            _lastPacketReceivedTicks = packet.ReceivedTicks;
-            _lastPacketTimestamp = expectedTimestampMs;
+            _lastPacketReceivedTicks = ticksElapsed;
+            _lastPacketTimestamp = samplesElapsed;
             return;
         }
 
-        double actualIntervalMs = (packet.ReceivedTicks - _lastPacketReceivedTicks) * 1000.0 / Stopwatch.Frequency;
-        double expectedIntervalMs = expectedTimestampMs - _lastPacketTimestamp;
+        double actualInterval = (double)(ticksElapsed - _lastPacketReceivedTicks) / Stopwatch.Frequency;
+        double expectedInterval = (double)(samplesElapsed - _lastPacketTimestamp) / OpenFreqRtcClient.SAMPLE_RATE;
     
         // Detect transmission gap (PTT released).
-        if (expectedIntervalMs > 500)
+        if (expectedInterval > 0.5)
         {
-            _logger.LogInformation("Transmission gap detected ({IntervalMs:F0}ms RTP delta), resetting jitter measurement", expectedIntervalMs);
+            _logger.LogInformation("Transmission gap detected ({IntervalMs:F0}ms RTP delta), resetting jitter measurement",
+                expectedInterval * 1000.0);
             _jitterSamples.Clear();
             _measuredJitterMs = 0;
-            _lastPacketReceivedTicks = packet.ReceivedTicks;
-            _lastPacketTimestamp = expectedTimestampMs;
+            _lastPacketReceivedTicks = ticksElapsed;
+            _lastPacketTimestamp = samplesElapsed;
             return;
         }
     
         // Normal jitter calculation
-        double jitter = Math.Abs(actualIntervalMs - expectedIntervalMs);
+        double jitterMs = Math.Abs(actualInterval - expectedInterval) * 1000;
     
-        _jitterSamples.Enqueue(jitter);
+        _jitterSamples.Enqueue(jitterMs);
         if (_jitterSamples.Count > 50)
             _jitterSamples.Dequeue();
     
@@ -277,8 +223,8 @@ public class RtpJitterBuffer
             _measuredJitterMs = _jitterSamples.Average();
         }
     
-        _lastPacketReceivedTicks = packet.ReceivedTicks;
-        _lastPacketTimestamp = expectedTimestampMs;
+        _lastPacketReceivedTicks = ticksElapsed;
+        _lastPacketTimestamp = samplesElapsed;
     }
         
     /// <summary>
@@ -305,31 +251,6 @@ public class RtpJitterBuffer
         _targetBufferMs = Math.Clamp(_targetBufferMs, MIN_BUFFER_MS, MAX_BUFFER_MS);
     }
 
-    /// <summary>
-    /// Nudges the playout clock to steer actual buffer depth towards the
-    /// target. Called each time a packet is dequeued so corrections are
-    /// applied incrementally rather than in a single jump.
-    /// Buffer deeper than target  → advance clock slightly (drain faster).
-    /// Buffer shallower than target → retard clock slightly (let it fill).
-    /// </summary>
-    private void AdjustPlayoutClock()
-    {
-        // _buffer is already locked by the caller (GetNextPacket)
-        int targetPackets = (int)Math.Round(_targetBufferMs / RtpAudioReceiver.PLAYOUT_INTERVAL_MS);
-        int error = _buffer.Count - targetPackets;
-
-        if (Math.Abs(error) <= 1)
-            return;
-
-        // 1ms nudge per dequeued packet
-        long nudgeTicks = (long)(0.001 * Stopwatch.Frequency);
-
-        if (error > 1)
-            _playoutStartTicks -= nudgeTicks; // clock advances → releases packets sooner
-        else
-            _playoutStartTicks += nudgeTicks; // clock retards → holds packets longer
-    }
-    
         
     /// <summary>
     /// Get buffer statistics
@@ -359,33 +280,7 @@ public class RtpJitterBuffer
             bufferedCount
         );
     }
-        
-    /// <summary>
-    /// Reset jitter buffer
-    /// </summary>
-    public void Reset()
-    {
-        lock (_buffer)
-        {
-            _buffer.Clear();
-            _jitterSamples.Clear();
-            _initialized = false;
-            _firstPacketPlayed = false;
-            _baseTimeTicks = 0;
-            _playoutStartTicks = 0;
-            _lastPacketReceivedTicks = 0;
-            _lastPacketTimestamp = 0;
-            _packetsReceived = 0;
-            _packetsLost = 0;
-            _packetsLate = 0;
-            _packetsDuplicate = 0;
-            _packetsPlayed = 0;
-        }
-    }
-        
-   
-    public double GetBufferSizeMs() => _targetBufferMs;
-        
+
     /// <summary>
     /// Set target buffer size (for manual override)
     /// </summary>

--- a/OpenFreq.Common/RTPPacket.cs
+++ b/OpenFreq.Common/RTPPacket.cs
@@ -1,4 +1,4 @@
-﻿namespace OpenFreq.Common.Rtp;
+namespace OpenFreq.Common.Rtp;
 
 public class RtpPacket
 {
@@ -9,6 +9,9 @@ public class RtpPacket
     public bool Marker { get; set; }  // Standard RTP marker bit (currently unused)
     public byte PayloadType { get; set; }
     public ushort SequenceNumber { get; set; }
+    /// <summary>
+    /// Timestamp since the start of the stream in samples
+    /// </summary>
     public uint Timestamp { get; set; }
     public uint Ssrc { get; set; }
 

--- a/OpenFreq.Common/RtpSourceContext.cs
+++ b/OpenFreq.Common/RtpSourceContext.cs
@@ -43,6 +43,5 @@ public sealed class RtpSourceContext : IDisposable
     public void Dispose()
     {
         OpusDecoder?.Dispose();
-        JitterBuffer.Reset();
     }
 }

--- a/OpenFreq.Testclient/TestClient.cs
+++ b/OpenFreq.Testclient/TestClient.cs
@@ -364,7 +364,7 @@ public class TestClientWrapper : IDisposable
             Console.WriteLine($"[BUFFER RESET] Was {bufferMs:F1}ms");
         }
     
-        Bass.StreamPutData(_playbackStream, e.AudioData, e.AudioData.Length);
+        Bass.StreamPutData(_playbackStream, e.AudioData.ToArray(), e.AudioData.Length);
     }
 
     private void OnError(object? sender, ErrorEventArgs errorEventArgs)


### PR DESCRIPTION
Prior to messing with the RX tick, fix FEC: it's only on the *last*, not first, missing packet

While we're at it, remove redundant branches for FEC vs PLC. Opus transparently falls back from the former to the latter when FEC isn't available and doesn't inform us when. See
https://github.com/lostromb/concentus/blob/master/CSharp/Concentus/Opus/Structs/OpusDecoder.cs#L730-L732
https://opus-codec.org/docs/opus_api-1.5/group__opus__decoder.html#ga7d1111f64c36027ddcb81799df9b3fc9

Also

- Fix TX timestamp so it's not just packet number * 960
- Remove markers
- Remove a bunch of redundant state from jitter buffers. (Most usefully, instead of sliding a fake start time around, use `_targetBufferMs` as our feedback).