### PR TITLE
No timers, fix rollover logic

### DIFF
--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -176,11 +176,11 @@ public class RtpAudioReceiver : IDisposable
                                     // Loss detection and concealment — per-source sequence
                                     if (context.FirstPacketReceived)
                                     {
-                                        ushort expectedSeq = (ushort)(context.LastSequenceReceived + 1);
+                                        long expectedSeq = context.LastSequenceReceived + 1;
 
                                         if (p.SequenceNumber != expectedSeq)
                                         {
-                                            int gap = RtpPacket.SequenceDifference(p.SequenceNumber, expectedSeq);
+                                            long gap = p.SequenceNumber - expectedSeq;
 
                                             if (gap > 0 && gap < 100)
                                             {
@@ -188,7 +188,7 @@ public class RtpAudioReceiver : IDisposable
                                                     "SSRC={Ssrc:X8}: {Gap} lost packet(s) (seq {Start} to {End}), generating concealment",
                                                     context.Ssrc, gap, expectedSeq, p.SequenceNumber - 1);
 
-                                                for (int i = 0; i < gap; i++)
+                                                for (long i = 0; i < gap; i++)
                                                 {
                                                     ushort lostSeq = (ushort)(expectedSeq + i);
                                                     // Only the last lost packet can use FEC (next packet carries FEC for it)
@@ -256,17 +256,17 @@ public class RtpAudioReceiver : IDisposable
     /// <summary>
     /// Process a packet that is ready for playout, using the source's own Opus decoder.
     /// </summary>
-    private void ProcessReadyPacket(RtpPacket packet, RtpSourceContext context)
+    private void ProcessReadyPacket(SequencedPacket packet, RtpSourceContext context)
     {
         try
         {
-            if (packet.ExtensionData is not { Length: > 0 })
+            if (packet.Metadata is not { Length: > 0 })
             {
                 _logger.LogWarning("SSRC={Ssrc:X8}: missing RTP header extension metadata", context.Ssrc);
                 return;
             }
 
-            var metadataJson = Encoding.UTF8.GetString(packet.ExtensionData).TrimEnd('\0');
+            var metadataJson = Encoding.UTF8.GetString(packet.Metadata).TrimEnd('\0');
             var metadata = JsonSerializer.Deserialize(metadataJson, OpenFreqJsonContext.Default.AudioPacketMetadata);
 
             if (metadata == null)
@@ -310,7 +310,7 @@ public class RtpAudioReceiver : IDisposable
     /// <summary>
     /// Generate FEC or PLC concealment audio for a lost packet within one source's context.
     /// </summary>
-    private void GenerateConcealmentAudio(ushort lostSequence, RtpPacket? nextPacket, RtpSourceContext context)
+    private void GenerateConcealmentAudio(ushort lostSequence, SequencedPacket? nextPacket, RtpSourceContext context)
     {
         try
         {

--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -1,11 +1,13 @@
-﻿using Concentus.Structs;
+using Concentus.Structs;
 using Microsoft.Extensions.Logging;
 using OpenFreq.Common.Rtp;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
+using static OpenFreq.Common.RtpJitterBuffer;
 
 // This is to avoid issues in Linux where the Concentus Factory methods does not work currently.
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -32,11 +34,10 @@ public class RtpAudioReceiver : IDisposable
     private readonly UdpClient _udpClient;
     private readonly RtpJitterBufferPool _pool;
     private readonly bool _opusEnabled;
-    private readonly CancellationTokenSource _cts = new();
-    private readonly Timer _playoutTimer;
 
-    // Prune stale sources every N ticks (20ms * 50 = 1s)
-    private int _pruneCountdown = 50;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task _rxTask;
+    private readonly Task _playbackTask;
 
     private const int OPUS_FRAME_SAMPLES = 960; // 20ms at 48kHz (matches sender)
     public static int PLAYOUT_INTERVAL_MS = 20;
@@ -57,8 +58,8 @@ public class RtpAudioReceiver : IDisposable
         _logger.LogInformation("  Opus: {OpusEnabled}", _opusEnabled);
         _logger.LogInformation("  Initial buffer: {BufferMs}ms (adaptive, per-SSRC)", initialBufferMs);
 
-        Task.Run(() => ReceiveLoop(), _cts.Token);
-        _playoutTimer = new Timer(PlayoutTimerCallback, null, 0, PLAYOUT_INTERVAL_MS);
+        _rxTask = Task.Run(() => ReceiveLoop(), _cts.Token);
+        _playbackTask = Task.Run(() => PlaybackLoop());
 
         if (!_logger.IsEnabled(LogLevel.Debug))
         {
@@ -84,7 +85,7 @@ public class RtpAudioReceiver : IDisposable
     {
         _logger.LogInformation("Receive loop started");
 
-        while (!_cts.Token.IsCancellationRequested)
+        while (!_cts.IsCancellationRequested)
         {
             try
             {
@@ -132,9 +133,12 @@ public class RtpAudioReceiver : IDisposable
                 _logger.LogWarning("Invalid RTP packet");
                 return;
             }
-
-            // Pool demuxes by SSRC automatically
-            _pool.AddPacket(rtpPacket);
+            lock (_pool)
+            {
+                _pool.AddPacket(rtpPacket);
+                // Wake the playback loop, we have new packets.
+                Monitor.Pulse(_pool);
+            }
         }
         catch (Exception ex)
         {
@@ -146,55 +150,100 @@ public class RtpAudioReceiver : IDisposable
     /// Playout timer callback. Polls every active SSRC for a ready packet,
     /// performing per-source FEC/PLC concealment independently.
     /// </summary>
-    private void PlayoutTimerCallback(object? state)
+    private void PlaybackLoop()
     {
         try
         {
-            // Prune sources that have gone silent
-            if (--_pruneCountdown <= 0)
+            while (!_cts.IsCancellationRequested)
             {
-                _pool.PruneStale();
-                _pruneCountdown = 50;
-            }
+                var now = Stopwatch.GetTimestamp();
 
-            foreach (var context in _pool.GetActiveSources())
-            {
-                // One packet per SSRC per 20ms tick — burst delivery is handled
-                // by AdjustPlayoutClock advancing the playout clock incrementally.
-                if (context.JitterBuffer.GetNextPacket() is { } packet)
+                // All the state we need to playback is in the jitter pool.
+                // Runs mutually exclusive with adding a new packet.
+                lock (_pool)
                 {
-
-                    // Loss detection and concealment — per-source sequence
-                    if (context.FirstPacketReceived)
+                    _pool.PruneStale(now);
+                    long? ticksToSleep = null;
+                    bool handledPackets = false;
+                    foreach (var context in _pool.GetActiveSources())
                     {
-                        ushort expectedSeq = (ushort)(context.LastSequenceReceived + 1);
-
-                        if (packet.SequenceNumber != expectedSeq)
+                        PacketsReadyResult rp = context.JitterBuffer.GetReadyPackets(now);
+                        switch (rp)
                         {
-                            int gap = RtpPacket.SequenceDifference(packet.SequenceNumber, expectedSeq);
-
-                            if (gap > 0 && gap < 100)
-                            {
-                                _logger.LogDebug(
-                                    "SSRC={Ssrc:X8}: {Gap} lost packet(s) (seq {Start} to {End}), generating concealment",
-                                    context.Ssrc, gap, expectedSeq, packet.SequenceNumber - 1);
-
-                                for (int i = 0; i < gap; i++)
+                            case PacketsReady pr:
+                                foreach (var p in pr.Packets)
                                 {
-                                    ushort lostSeq = (ushort)(expectedSeq + i);
-                                    // Only the last lost packet can use FEC (next packet carries FEC for it)
-                                    GenerateConcealmentAudio(lostSeq, i == gap - 1 ? packet : null, context);
+                                    // Loss detection and concealment — per-source sequence
+                                    if (context.FirstPacketReceived)
+                                    {
+                                        ushort expectedSeq = (ushort)(context.LastSequenceReceived + 1);
+
+                                        if (p.SequenceNumber != expectedSeq)
+                                        {
+                                            int gap = RtpPacket.SequenceDifference(p.SequenceNumber, expectedSeq);
+
+                                            if (gap > 0 && gap < 100)
+                                            {
+                                                _logger.LogDebug(
+                                                    "SSRC={Ssrc:X8}: {Gap} lost packet(s) (seq {Start} to {End}), generating concealment",
+                                                    context.Ssrc, gap, expectedSeq, p.SequenceNumber - 1);
+
+                                                for (int i = 0; i < gap; i++)
+                                                {
+                                                    ushort lostSeq = (ushort)(expectedSeq + i);
+                                                    // Only the last lost packet can use FEC (next packet carries FEC for it)
+                                                    GenerateConcealmentAudio(lostSeq, i == gap - 1 ? p : null, context);
+                                                }
+                                            }
+                                        }
+                                    }
+                                    else
+                                    {
+                                        context.FirstPacketReceived = true;
+                                    }
+
+                                    context.LastSequenceReceived = p.SequenceNumber;
+                                    ProcessReadyPacket(p, context);
                                 }
-                            }
+                                handledPackets = true;
+                                break;
+
+                            case WaitFor wf:
+                                if (ticksToSleep.HasValue)
+                                {
+                                    ticksToSleep = Math.Min(ticksToSleep.Value, wf.Ticks);
+                                }
+                                else
+                                {
+                                    ticksToSleep = wf.Ticks;
+                                }
+                                break;
+
+                            case NoPackets:
+                                break;
+
+                            default: throw new UnreachableException();
+                        };
+                    }
+
+                    // If we handled some packets,
+                    // go again immediately, we might have more.
+                    if (handledPackets) continue;
+                    // Otherwise wait until something happens - a new packet,
+                    // some ready to play, etc.
+                    if (ticksToSleep.HasValue)
+                    {
+                        var t = ticksToSleep.Value;
+                        var ms = (int)((double)t / Stopwatch.Frequency * 1000.0);
+                        if (ms > 0)
+                        {
+                            Monitor.Wait(_pool, ms);
                         }
                     }
                     else
                     {
-                        context.FirstPacketReceived = true;
+                        Monitor.Wait(_pool);
                     }
-
-                    context.LastSequenceReceived = packet.SequenceNumber;
-                    ProcessReadyPacket(packet, context);
                 }
             }
         }
@@ -375,13 +424,16 @@ public class RtpAudioReceiver : IDisposable
         _logger.LogInformation("================================");
     }
 
-    public void SetJitterBufferSize(int milliseconds)
-        => _pool.SetAllBufferSizes(milliseconds);
-
     public void Dispose()
     {
+        // Cancel our background tasks and wake them up.
         _cts.Cancel();
-        _playoutTimer.Dispose();
+        lock (_pool)
+        {
+            Monitor.PulseAll(_pool);
+        }
+        _rxTask.Wait();
+        _playbackTask.Wait();
         PrintStatistics();
         _pool.Dispose();
         _logger.LogInformation("Disposed");

--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -1,12 +1,9 @@
-using Concentus.Structs;
 using Microsoft.Extensions.Logging;
 using OpenFreq.Common.Rtp;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.Json;
+using System.Threading.Channels;
 using static OpenFreq.Common.RtpJitterBuffer;
 
 // This is to avoid issues in Linux where the Concentus Factory methods does not work currently.
@@ -37,10 +34,15 @@ public class RtpAudioReceiver : IDisposable
 
     private readonly CancellationTokenSource _cts = new();
     private readonly Task _rxTask;
-    private readonly Task _playbackTask;
-
-    private const int OPUS_FRAME_SAMPLES = 960; // 20ms at 48kHz (matches sender)
-    public static int PLAYOUT_INTERVAL_MS = 20;
+    // NB: Draining the jitter buffer has no awaits, and blocks its thread
+    // using Monitor.Wait(). (It wakes when packets are ready to leave
+    // the jitter buffer, or when new packets were just fed in - see the
+    // Monitor.Pulse() in the RX task.)
+    // Give it a dedicated thread instead of betting on the goodwill of
+    // the .NET runtime to notice when we're blocking one of the threads
+    // in its async pool.
+    private readonly Thread _jitterDrainThread;
+    private readonly Task _playTask;
 
     public RtpAudioReceiver(ILoggerFactory loggerFactory, UdpClient udpClient, bool opusEnabled = true,
         int initialBufferMs = 150)
@@ -48,7 +50,13 @@ public class RtpAudioReceiver : IDisposable
         _logger = loggerFactory.CreateLogger<RtpAudioReceiver>();
         _opusEnabled = opusEnabled;
 
-        _pool = new RtpJitterBufferPool(loggerFactory, opusEnabled, initialBufferMs);
+        var playChan = Channel.CreateBounded<AudioReceivedEventArgs>(new BoundedChannelOptions(128)
+        {
+            SingleReader = true,
+            FullMode = BoundedChannelFullMode.DropOldest
+        });
+
+        _pool = new RtpJitterBufferPool(loggerFactory, _cts.Token, playChan.Writer, opusEnabled, initialBufferMs);
         _pool.SourceAdded += ssrc => _logger.LogInformation("Source joined:  SSRC={Ssrc:X8}", ssrc);
         _pool.SourceExpired += ssrc => _logger.LogInformation("Source expired: SSRC={Ssrc:X8}", ssrc);
 
@@ -59,13 +67,15 @@ public class RtpAudioReceiver : IDisposable
         _logger.LogInformation("  Initial buffer: {BufferMs}ms (adaptive, per-SSRC)", initialBufferMs);
 
         _rxTask = Task.Run(() => ReceiveLoop(), _cts.Token);
-        _playbackTask = Task.Run(() => PlaybackLoop());
+        _jitterDrainThread = new Thread(DrainJitterBuffers);
+        _jitterDrainThread.Start();
+        _playTask = Task.Run(() => PlayTask(playChan.Reader));
 
-        if (!_logger.IsEnabled(LogLevel.Debug))
+        if (_logger.IsEnabled(LogLevel.Debug))
         {
             Task.Run(async () =>
                 {
-                    while (true)
+                    while (_cts.IsCancellationRequested)
                     {
                         var stats = GetStatistics();
                         _logger.LogDebug("Network Stats (aggregated)");
@@ -150,7 +160,7 @@ public class RtpAudioReceiver : IDisposable
     /// Playout timer callback. Polls every active SSRC for a ready packet,
     /// performing per-source FEC/PLC concealment independently.
     /// </summary>
-    private void PlaybackLoop()
+    private void DrainJitterBuffers()
     {
         try
         {
@@ -173,37 +183,8 @@ public class RtpAudioReceiver : IDisposable
                             case PacketsReady pr:
                                 foreach (var p in pr.Packets)
                                 {
-                                    // Loss detection and concealment — per-source sequence
-                                    if (context.FirstPacketReceived)
-                                    {
-                                        long expectedSeq = context.LastSequenceReceived + 1;
-
-                                        if (p.SequenceNumber != expectedSeq)
-                                        {
-                                            long gap = p.SequenceNumber - expectedSeq;
-
-                                            if (gap > 0 && gap < 100)
-                                            {
-                                                _logger.LogDebug(
-                                                    "SSRC={Ssrc:X8}: {Gap} lost packet(s) (seq {Start} to {End}), generating concealment",
-                                                    context.Ssrc, gap, expectedSeq, p.SequenceNumber - 1);
-
-                                                for (long i = 0; i < gap; i++)
-                                                {
-                                                    ushort lostSeq = (ushort)(expectedSeq + i);
-                                                    // Only the last lost packet can use FEC (next packet carries FEC for it)
-                                                    GenerateConcealmentAudio(lostSeq, i == gap - 1 ? p : null, context);
-                                                }
-                                            }
-                                        }
-                                    }
-                                    else
-                                    {
-                                        context.FirstPacketReceived = true;
-                                    }
-
-                                    context.LastSequenceReceived = p.SequenceNumber;
-                                    ProcessReadyPacket(p, context);
+                                    // Always succeeds; channel drops oldest on full.
+                                    context.ToDecode.TryWrite(p);
                                 }
                                 handledPackets = true;
                                 break;
@@ -223,7 +204,7 @@ public class RtpAudioReceiver : IDisposable
                                 break;
 
                             default: throw new UnreachableException();
-                        };
+                        }
                     }
 
                     // If we handled some packets,
@@ -253,145 +234,19 @@ public class RtpAudioReceiver : IDisposable
         }
     }
 
-    /// <summary>
-    /// Process a packet that is ready for playout, using the source's own Opus decoder.
-    /// </summary>
-    private void ProcessReadyPacket(SequencedPacket packet, RtpSourceContext context)
+    private async Task PlayTask(ChannelReader<AudioReceivedEventArgs> chan)
     {
-        try
+        while (!_cts.IsCancellationRequested)
         {
-            if (packet.Metadata is not { Length: > 0 })
+            try
             {
-                _logger.LogWarning("SSRC={Ssrc:X8}: missing RTP header extension metadata", context.Ssrc);
-                return;
+                var e = await chan.ReadAsync(_cts.Token);
+                AudioReceived?.Invoke(this, e);
             }
-
-            var metadataJson = Encoding.UTF8.GetString(packet.Metadata).TrimEnd('\0');
-            var metadata = JsonSerializer.Deserialize(metadataJson, OpenFreqJsonContext.Default.AudioPacketMetadata);
-
-            if (metadata == null)
+            catch (OperationCanceledException)
             {
-                _logger.LogWarning("SSRC={Ssrc:X8}: failed to parse metadata", context.Ssrc);
-                return;
+                break;
             }
-
-            context.LastValidMetadata = metadata;
-
-            Memory<short> decodedAudio;
-            if (_opusEnabled && context.OpusDecoder != null)
-            {
-                decodedAudio = DecodeOpus(packet.Payload, context.OpusDecoder, decodeFec: false);
-                if (decodedAudio.Length == 0)
-                    return;
-            }
-            else
-            {
-                var buf = new short[packet.Payload.Length / 2];
-                decodedAudio = new Memory<short>(buf);
-                packet.Payload.CopyTo(MemoryMarshal.AsBytes(decodedAudio.Span));
-            }
-
-            #if DEBUG
-            _logger.LogDebug($"Playing packet from {packet.Ssrc}: {packet.SequenceNumber}");
-            #endif
-            
-            AudioReceived?.Invoke(this, new AudioReceivedEventArgs
-            {
-                AudioData = decodedAudio,
-                Metadata = metadata
-            });
-        }
-        catch (Exception ex)
-        {
-            ErrorOccurred?.Invoke(this, $"Ready packet processing error: {ex.Message}");
-        }
-    }
-
-    /// <summary>
-    /// Generate FEC or PLC concealment audio for a lost packet within one source's context.
-    /// </summary>
-    private void GenerateConcealmentAudio(ushort lostSequence, SequencedPacket? nextPacket, RtpSourceContext context)
-    {
-        try
-        {
-            Memory<short> concealmentAudio;
-
-            byte[] nextOpusData = nextPacket?.Payload ?? [];
-
-            _logger.LogDebug(
-                "SSRC={Ssrc:X8}: loss recovery for seq {LostSeq}: {Bytes} bytes",
-                context.Ssrc, lostSequence, nextOpusData.Length);
-
-            concealmentAudio = DecodeOpus(nextOpusData, context.OpusDecoder, decodeFec: nextPacket != null);
-
-            if (concealmentAudio.Length == 0)
-                return;
-
-            var frequencies = new List<FrequencyTransmission>();
-            if (context.LastValidMetadata?.Frequencies != null)
-            {
-                foreach (var freq in context.LastValidMetadata.Frequencies)
-                {
-                    frequencies.Add(new FrequencyTransmission(
-                        khz: freq.Khz,
-                        txPowerWatts: freq.TxPowerWatts,
-                        ppm: freq.Ppm,
-                        position: freq.Position,
-                        velocity: freq.Velocity,
-                        in3d: freq.In3d,
-                        ambientNoiseType: freq.AmbientNoiseType
-                    ));
-                }
-            }
-
-            var metadata = new AudioPacketMetadata
-            {
-                ClientId = context.LastValidMetadata?.ClientId ?? "Recovered",
-                Frequencies = frequencies
-            };
-
-            AudioReceived?.Invoke(this, new AudioReceivedEventArgs
-            {
-                AudioData = concealmentAudio,
-                Metadata = metadata
-            });
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "SSRC={Ssrc:X8}: failed to generate concealment for seq {LostSeq}",
-                context.Ssrc, lostSequence);
-        }
-    }
-
-    /// <summary>
-    /// Decode Opus audio using the provided decoder instance (one per SSRC).
-    /// </summary>
-    private Memory<short> DecodeOpus(ReadOnlySpan<byte> opusData, OpusDecoder decoder, bool decodeFec)
-    {
-        try
-        {
-            short[] pcmSamples = new short[OPUS_FRAME_SAMPLES];
-            var outSpan = new Memory<short>(pcmSamples);
-
-            int samplesDecoded;
-
-            // We're actually looking for the _previous_ packet,
-            // which can be FEC'd into the next in case it gets lost.
-            samplesDecoded = decoder.Decode(
-                opusData, outSpan.Span, OPUS_FRAME_SAMPLES, decodeFec);
-
-            if (samplesDecoded <= 0)
-            {
-                _logger.LogWarning("Opus decode failed for {ByteCount} bytes (decodeFec={DecodeFec})",
-                    opusData.Length, decodeFec);
-                return Memory<short>.Empty;
-            }
-            return outSpan[..samplesDecoded];
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Opus decode exception (decodeFec={DecodeFec})", decodeFec);
-            return Memory<short>.Empty;
         }
     }
 
@@ -426,16 +281,26 @@ public class RtpAudioReceiver : IDisposable
 
     public void Dispose()
     {
-        // Cancel our background tasks and wake them up.
+        // 1. Signal everything to stop.
         _cts.Cancel();
+        // 2. Wake the drain thread if it's in Monitor.Wait.
         lock (_pool)
         {
             Monitor.PulseAll(_pool);
         }
+        // 3. No more packets entering the system.
         _rxTask.Wait();
-        _playbackTask.Wait();
+        // 4. Drain thread done — no more packets dispatched to decode channels.
+        _jitterDrainThread.Join();
+        // 5. Play task already exited (cancellation token in ReadAsync).
+        _playTask.Wait();
+        // 6. All tasks quiesced — stats are stable. Must run before pool.Dispose
+        //    clears _sources.
         PrintStatistics();
+        // 7. Complete each source's decode channel, wait for its decoder task
+        //    to finish, then dispose its Opus decoder.
         _pool.Dispose();
+        _cts.Dispose();
         _logger.LogInformation("Disposed");
     }
 }

--- a/OpenFreq.Common/RTPJitterBufferPool.cs
+++ b/OpenFreq.Common/RTPJitterBufferPool.cs
@@ -1,7 +1,9 @@
-using System.Collections.Concurrent;
-using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using OpenFreq.Common.Rtp;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Threading.Channels;
+using static OpenFreq.Common.RtpAudioReceiver;
 
 namespace OpenFreq.Common;
 
@@ -12,6 +14,8 @@ public sealed class RtpJitterBufferPool : IDisposable
 {
     private readonly ILogger<RtpJitterBufferPool> _logger;
     private readonly ILoggerFactory _loggerFactory;
+    private readonly CancellationToken _cancelled;
+    private readonly ChannelWriter<AudioReceivedEventArgs> _player;
     private readonly bool _opusEnabled;
     private readonly int _initialBufferMs;
 
@@ -28,10 +32,17 @@ public sealed class RtpJitterBufferPool : IDisposable
     /// <summary>Fired just before a stale source is removed.</summary>
     public event Action<uint>? SourceExpired;
 
-    public RtpJitterBufferPool(ILoggerFactory loggerFactory, bool opusEnabled, int initialBufferMs)
+    public RtpJitterBufferPool(
+        ILoggerFactory loggerFactory,
+        CancellationToken ct,
+        ChannelWriter<AudioReceivedEventArgs> player,
+        bool opusEnabled,
+        int initialBufferMs)
     {
         _loggerFactory = loggerFactory;
         _logger = loggerFactory.CreateLogger<RtpJitterBufferPool>();
+        _cancelled = ct;
+        _player = player;
         _opusEnabled = opusEnabled;
         _initialBufferMs = initialBufferMs;
     }
@@ -47,7 +58,7 @@ public sealed class RtpJitterBufferPool : IDisposable
         if (!_sources.TryGetValue(ssrc, out src))
         {
             _logger.LogInformation("New RTP source: SSRC={Ssrc:X8}", ssrc);
-            src = new RtpSourceContext(ssrc, _loggerFactory, _opusEnabled, _initialBufferMs);
+            src = new RtpSourceContext(ssrc, _loggerFactory, _cancelled, _player, _opusEnabled, _initialBufferMs);
             _sources.Add(ssrc, src);
             SourceAdded?.Invoke(ssrc);
         }

--- a/OpenFreq.Common/RTPJitterBufferPool.cs
+++ b/OpenFreq.Common/RTPJitterBufferPool.cs
@@ -15,7 +15,7 @@ public sealed class RtpJitterBufferPool : IDisposable
     private readonly bool _opusEnabled;
     private readonly int _initialBufferMs;
 
-    private readonly ConcurrentDictionary<uint, RtpSourceContext> _sources = new();
+    private readonly Dictionary<uint, RtpSourceContext> _sources = new();
 
     /// <summary>
     /// How long a source must be silent before it is pruned from the pool.
@@ -42,54 +42,48 @@ public sealed class RtpJitterBufferPool : IDisposable
     /// </summary>
     public void AddPacket(RtpPacket packet)
     {
-        var context = _sources.GetOrAdd(packet.Ssrc, ssrc =>
+        var ssrc = packet.Ssrc;
+        RtpSourceContext? src;
+        if (!_sources.TryGetValue(ssrc, out src))
         {
             _logger.LogInformation("New RTP source: SSRC={Ssrc:X8}", ssrc);
-            var ctx = new RtpSourceContext(ssrc, _loggerFactory, _opusEnabled, _initialBufferMs);
+            src = new RtpSourceContext(ssrc, _loggerFactory, _opusEnabled, _initialBufferMs);
+            _sources.Add(ssrc, src);
             SourceAdded?.Invoke(ssrc);
-            return ctx;
-        });
+        }
 
-        context.LastActivityTicks = Stopwatch.GetTimestamp();
-        context.JitterBuffer.AddPacket(packet);
+        src.LastActivityTicks = Stopwatch.GetTimestamp();
+        src.JitterBuffer.AddPacket(packet);
     }
 
     /// <summary>
     /// Returns a point-in-time snapshot of all currently active source contexts.
     /// Safe to iterate while new packets arrive concurrently.
     /// </summary>
-    public IReadOnlyList<RtpSourceContext> GetActiveSources()
-        => _sources.Values.ToList();
+    public IEnumerable<RtpSourceContext> GetActiveSources()
+        => _sources.Values;
 
     /// <summary>
     /// Removes sources that have not received a packet within <see cref="SourceTimeoutMs"/>.
     /// </summary>
-    public void PruneStale()
+    public void PruneStale(long now)
     {
         var threshold = (long)(SourceTimeoutMs / 1000.0 * Stopwatch.Frequency);
-        var now = Stopwatch.GetTimestamp();
-
+        List<uint> toRemove = [];
         foreach (var (ssrc, context) in _sources)
         {
             if (now - context.LastActivityTicks <= threshold)
                 continue;
 
-            if (_sources.TryRemove(ssrc, out var removed))
-            {
-                _logger.LogInformation("Pruned stale source SSRC={Ssrc:X8}", ssrc);
-                SourceExpired?.Invoke(ssrc);
-                removed.Dispose();
-            }
+            toRemove.Add(ssrc);
         }
-    }
-
-    /// <summary>
-    /// Override the jitter buffer target size on all current (and future) sources.
-    /// </summary>
-    public void SetAllBufferSizes(int milliseconds)
-    {
-        foreach (var context in _sources.Values)
-            context.JitterBuffer.SetTargetBufferSize(milliseconds);
+        foreach (var r in toRemove)
+        {
+            _logger.LogInformation("Pruned stale source SSRC={Ssrc:X8}", r);
+            SourceExpired?.Invoke(r);
+            _sources.Remove(r, out var removed);
+            removed!.Dispose();
+        }
     }
 
     /// <summary>
@@ -98,14 +92,11 @@ public sealed class RtpJitterBufferPool : IDisposable
     public (int received, int lost, int late, int duplicate, int played,
         double lossPercent, double jitterMs, double bufferMs, int buffered) GetStatistics()
     {
-        var sources = GetActiveSources();
-        if (sources.Count == 0)
-            return (0, 0, 0, 0, 0, 0.0, 0.0, 0.0, 0);
-
         int received = 0, lost = 0, late = 0, duplicate = 0, played = 0, buffered = 0;
         double jitterSum = 0, bufferSum = 0;
+        int numSources = 0;
 
-        foreach (var ctx in sources)
+        foreach (var ctx in GetActiveSources())
         {
             var s = ctx.JitterBuffer.GetStatistics();
             received  += s.received;
@@ -116,7 +107,11 @@ public sealed class RtpJitterBufferPool : IDisposable
             buffered  += s.buffered;
             jitterSum += s.jitterMs;
             bufferSum += s.bufferMs;
+            numSources++;
         }
+
+        if (numSources == 0)
+            return (0, 0, 0, 0, 0, 0.0, 0.0, 0.0, 0);
 
         double lossPercent = (received + lost) > 0
             ? 100.0 * lost / (received + lost)
@@ -124,8 +119,8 @@ public sealed class RtpJitterBufferPool : IDisposable
 
         return (received, lost, late, duplicate, played,
             lossPercent,
-            jitterSum  / sources.Count,   // average jitter across sources
-            bufferSum  / sources.Count,   // average buffer size across sources
+            jitterSum  / numSources,   // average jitter across sources
+            bufferSum  / numSources,   // average buffer size across sources
             buffered);
     }
 

--- a/OpenFreq.Common/RTPJitterbuffer.cs
+++ b/OpenFreq.Common/RTPJitterbuffer.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using OpenFreq.Common.Rtp;
 
@@ -11,23 +11,14 @@ namespace OpenFreq.Common;
 public class RtpJitterBuffer
 {
     private readonly ILogger<RtpJitterBuffer> _logger;
-    
-    private class BufferedPacket
-    {
-        public required RtpPacket Packet { get; set; }
-        public long ReceivedTicks { get; set; }
-    }
+
     /// <summary>
     /// Sorts packets based on their (extended) sequence number
     /// </summary>
-    private readonly SortedDictionary<ushort, BufferedPacket> _buffer = new();
+    private readonly SortedDictionary<ushort, RtpPacket> _buffer = new();
     private readonly Queue<double> _jitterSamples = new(50);
     private readonly int _maxBufferPackets;
-        
-    /// <summary>
-    /// Once we've played a packet, the next expected one. Used to detect missing ones.
-    /// </summary>
-    private ushort? _nextExpectedSequence;
+
     /// <summary>
     /// Starting (extended) timestamp from the first packet
     /// </summary>
@@ -68,120 +59,99 @@ public class RtpJitterBuffer
     /// </summary>
     public void AddPacket(RtpPacket packet)
     {
-    
+        var now = Stopwatch.GetTimestamp();
+
         // Initialize on first packet
         if (_packetsReceived == 0)
         {
             _baseTimestamp = packet.Timestamp;
-            _baseTimeTicks = Stopwatch.GetTimestamp();
-
+            _baseTimeTicks = now;
             _logger.LogInformation("Initialized: buffer={BufferMs}ms", _targetBufferMs);
         }
         _packetsReceived++;
 
-        lock (_buffer)
+        // Check for duplicate
+        if (_buffer.ContainsKey(packet.SequenceNumber))
         {
+            _packetsDuplicate++;
+            return;
+        }
 
+        // Calculate playout time
+        long timestampDiff = RtpPacket.TimestampDifference(packet.Timestamp, _baseTimestamp);
 
-            // Check for duplicate
-            if (_buffer.ContainsKey(packet.SequenceNumber))
-            {
-                _packetsDuplicate++;
-                return;
-            }
+        // Add to buffer
+        _buffer[packet.SequenceNumber] = packet;
 
-            // Calculate playout time
-            long timestampDiff = RtpPacket.TimestampDifference(packet.Timestamp, _baseTimestamp);
+        var ticksDiff = now - _baseTimeTicks;
+        MeasureJitter(ticksDiff, timestampDiff);
 
-            var bufferedPacket = new BufferedPacket
-            {
-                Packet = packet,
-                ReceivedTicks = Stopwatch.GetTimestamp()
-            };
+        // Adapt buffer size
+        AdaptBufferSize();
 
-            // Add to buffer
-            _buffer[packet.SequenceNumber] = bufferedPacket;
-
-            MeasureJitter(bufferedPacket.ReceivedTicks, timestampDiff);
-
-            // Adapt buffer size
-            AdaptBufferSize();
-
-            // Limit buffer size
-            while (_buffer.Count > _maxBufferPackets)
-            {
-                var oldest = _buffer.Keys.First();
-                _buffer.Remove(oldest);
-                _logger.LogWarning("Buffer overflow, dropped seq {SequenceNumber}", oldest);
-            }
+        // Limit buffer size
+        while (_buffer.Count > _maxBufferPackets)
+        {
+            var oldest = _buffer.Keys.First();
+            _buffer.Remove(oldest);
+            _logger.LogWarning("Buffer overflow, dropped seq {SequenceNumber}", oldest);
         }
     }
-        
-    /// <summary>
-    /// Get next packet ready for playout
-    /// </summary>
-    public RtpPacket? GetNextPacket()
+
+    // Toy language doesn't have sum types/tagged unions,
+    // but apparently this is the closest we get since C# 9.
+    public abstract record PacketsReadyResult;
+    public record NoPackets : PacketsReadyResult;
+    public record PacketsReady(List<RtpPacket> Packets) : PacketsReadyResult;
+    public record WaitFor(long Ticks) : PacketsReadyResult;
+
+
+    public PacketsReadyResult GetReadyPackets(long now)
     {
-        if (_packetsReceived == 0 || _buffer.Count == 0)
-            return null;
+        // Bail if we've got nothing to play
+        if (_buffer.Count == 0)return new NoPackets();
 
-        var nowTicks = Stopwatch.GetTimestamp();
-        var elapsedTicks = nowTicks - _baseTimeTicks;
+        long elapsedTicks = now - _baseTimeTicks;
+        // The current jitter buffer length, in ticks.
+        long bufferDelayTicks = (long)(_targetBufferMs / 1000.0 * Stopwatch.Frequency);
+        // How many samples have elapsed, after applying the buffer delay?
+        long jitterAdjustedElapsedSamples = (long)(
+            (double)(elapsedTicks - bufferDelayTicks) /
+                Stopwatch.Frequency * OpenFreqRtcClient.SAMPLE_RATE);
 
-        // The playout position is "where the sender was _targetBufferMs ago".
-        // When _targetBufferMs changes (via AdaptBufferSize), this adjusts immediately.
-        long elapsedSamples = (long)((double)elapsedTicks * OpenFreqRtcClient.SAMPLE_RATE / Stopwatch.Frequency);
-        long bufferDelaySamples = (long)(_targetBufferMs / 1000.0 * OpenFreqRtcClient.SAMPLE_RATE);
-        uint playoutTimestamp = _baseTimestamp + (uint)(elapsedSamples - bufferDelaySamples);
-
-        KeyValuePair<ushort, BufferedPacket> nextPacket;
-        lock (_buffer)
+        List<RtpPacket> readies = [];
+        while (_buffer.Count > 0)
         {
-
-
-            // Find packets ready for playout
-            var readyPackets = _buffer
-                .Where(kvp => RtpPacket.TimestampDifference(playoutTimestamp, kvp.Value.Packet.Timestamp) >= 0)
-                .ToList();
-
-            if (readyPackets.Count == 0)
+            var first = _buffer.First();
+            var packet = first.Value;
+            var pt = packet.Timestamp - _baseTimestamp;
+            var samplesUntilReady = (long)pt - jitterAdjustedElapsedSamples;
+            if (samplesUntilReady > 0)
             {
-                return null;
-            }
-
-            // Get the packet with the lowest sequence number
-            nextPacket = readyPackets.First();
-            _buffer.Remove(nextPacket.Key);
-
-            // Check if this is the expected sequence (loss detection).
-            // Skip the check on the first packet
-            if (_nextExpectedSequence.HasValue)
-            {
-                var nextExpected = _nextExpectedSequence.Value;
-                var gap = RtpPacket.SequenceDifference(nextPacket.Key, nextExpected);
-                switch (gap)
+                // If no packets are ready,
+                // return the amount of time to wait until the first is.
+                if (readies.Count == 0)
                 {
-                    case > 0:
-                        // Skipped packets (loss)
-                        _packetsLost += gap;
-                        _logger.LogWarning("Packet loss: {Gap} packets (seq {ExpectedSeq} to {LastSeq})", 
-                            gap, nextExpected, nextPacket.Key - 1);
-                        break;
-                    case < 0:
-                        // Late packet
-                        _packetsLate++;
-                        _logger.LogWarning("Late packet seq {SequenceNumber} (expected {ExpectedSequence})", 
-                            nextPacket.Key, nextExpected);
-                        break;
+                    // Back to ticks
+                    var ticksUntilReady = (long)(
+                        (double)samplesUntilReady /
+                            OpenFreqRtcClient.SAMPLE_RATE * Stopwatch.Frequency);
+                    return new WaitFor(ticksUntilReady);
+                }
+                else
+                {
+                    break;
                 }
             }
-
-            _nextExpectedSequence = (ushort)(nextPacket.Key + 1);
-            _packetsPlayed++;
-
+            else
+            {
+                _buffer.Remove(first.Key);
+                readies.Add(packet);
+            }
         }
-
-        return nextPacket.Value.Packet;
+        _packetsPlayed += readies.Count;
+        // TODO other stats aggregation
+        return new PacketsReady(readies);
     }
         
     /// <summary>
@@ -196,6 +166,7 @@ public class RtpJitterBuffer
             _lastPacketTimestamp = samplesElapsed;
             return;
         }
+        if (samplesElapsed < _lastPacketTimestamp) ++_packetsLate;
 
         double actualInterval = (double)(ticksElapsed - _lastPacketReceivedTicks) / Stopwatch.Frequency;
         double expectedInterval = (double)(samplesElapsed - _lastPacketTimestamp) / OpenFreqRtcClient.SAMPLE_RATE;
@@ -216,7 +187,7 @@ public class RtpJitterBuffer
         double jitterMs = Math.Abs(actualInterval - expectedInterval) * 1000;
     
         _jitterSamples.Enqueue(jitterMs);
-        if (_jitterSamples.Count > 50)
+        while (_jitterSamples.Count > 50)
             _jitterSamples.Dequeue();
     
         if (_jitterSamples.Count >= 10)
@@ -263,11 +234,7 @@ public class RtpJitterBuffer
             ? (100.0 * _packetsLost) / (_packetsReceived + _packetsLost)
             : 0.0;
 
-        int bufferedCount;
-        lock (_buffer)
-        {
-            bufferedCount = _buffer.Count;
-        }
+        int bufferedCount = _buffer.Count;
 
         return (
             _packetsReceived, 

--- a/OpenFreq.Common/RTPJitterbuffer.cs
+++ b/OpenFreq.Common/RTPJitterbuffer.cs
@@ -1,8 +1,18 @@
 using System.Diagnostics;
+using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Logging;
 using OpenFreq.Common.Rtp;
 
 namespace OpenFreq.Common;
+
+public record SequencedPacket
+{
+    public required uint Ssrc { get; set; }
+    public required long SequenceNumber { get; set; }
+    public required long Timestamp { get; set; }
+    public required byte[] Payload { get; set; }
+    public required byte[]? Metadata { get; set; }
+}
 
 /// <summary>
 /// Adaptive RTP jitter buffer with timestamp-based playout scheduling.
@@ -15,7 +25,7 @@ public class RtpJitterBuffer
     /// <summary>
     /// Sorts packets based on their (extended) sequence number
     /// </summary>
-    private readonly SortedDictionary<ushort, RtpPacket> _buffer = new();
+    private readonly SortedDictionary<long, SequencedPacket> _buffer = new();
     private readonly Queue<double> _jitterSamples = new(50);
     private readonly int _maxBufferPackets;
 
@@ -28,11 +38,26 @@ public class RtpJitterBuffer
     /// Jitter is a comparison to the base timestamp
     /// </summary>
     private long _baseTimeTicks;
+    // rollover logic - see AddPacket()
+    private int _timestampEpoch = 0;
+    private int _sequenceEpoch = 0;
+    private uint _highestTimestamp = 0;
+    private ushort _highestSequence = 0;
     /// <summary>
     /// Local monotonic time when the last packet arrived.
     /// </summary>
     private long _lastPacketReceivedTicks;
+    /// <summary>
+    /// Timestamp (in extended samples) of the last packet
+    /// </summary>
     private long _lastPacketTimestamp;
+    /// <summary>
+    /// Sequence number of the last packet returned form this jitter buffer.
+    /// </summary>
+    /// <remarks>
+    /// Used to detect missing packets - i.e. gaps in the buffer.
+    /// </remarks>
+    private long? _lastReturnedPacket;
 
     // Adaptive jitter buffer parameters
     private double _targetBufferMs = 60; // Start with 60ms
@@ -66,24 +91,87 @@ public class RtpJitterBuffer
         {
             _baseTimestamp = packet.Timestamp;
             _baseTimeTicks = now;
+            _highestSequence = packet.SequenceNumber;
+            _highestTimestamp = packet.Timestamp;
             _logger.LogInformation("Initialized: buffer={BufferMs}ms", _targetBufferMs);
         }
         _packetsReceived++;
 
+        // Rollover handling (from RTP's RFC 3711, seciton 3.3.1):
+        // we can extend both the 16-bit sequence number _and_ the 32-bit timestamp
+        // to 64-bit values, in a way that handles rollover *and* out-of-order packets!
+        // This is very nice because it lets everything downstream never worry about
+        // rollover ever again. (2^63 samples @ 48kHz is 6 million years.)
+        var seqDelta = (short)(ushort)(packet.SequenceNumber - _highestSequence);
+        int seqEpoch;
+        if (seqDelta >= 0)
+        {
+            // If the delta is positive but the sequence is < highest,
+            // we've rolled over
+            if (packet.SequenceNumber < _highestSequence) ++_sequenceEpoch;
+            seqEpoch = _sequenceEpoch;
+            _highestSequence = packet.SequenceNumber;
+        }
+        else
+        {
+            // If the delta is <= 0 but sequence is > highest,
+            // it's a late packet from before the last rollover.
+            if (packet.SequenceNumber > _highestSequence)
+            {
+                seqEpoch = _sequenceEpoch - 1;
+            }
+            // Late packet without any rollover shenanigans:
+            else
+            {
+                seqEpoch = _sequenceEpoch;
+            }
+        }
+        // Our result is a 48-bit int.
+        long seq = (long)seqEpoch << 16 | (long)packet.SequenceNumber;
+
+        // Give timestamps the same treatment.
+        int tsDelta = (int)(packet.Timestamp - _highestTimestamp);
+        int tsEpoch;
+        if (tsDelta >= 0)
+        {
+            if (packet.Timestamp < _highestTimestamp) ++_timestampEpoch;
+            tsEpoch = _timestampEpoch;
+            _highestTimestamp = packet.Timestamp;
+        }
+        else
+        {
+            if (packet.Timestamp > _highestTimestamp)
+            {
+                tsEpoch = _timestampEpoch - 1;
+            }
+            else
+            {
+                tsEpoch = _timestampEpoch;
+            }
+        }
+        long ts = (long)tsEpoch << 32 | (long)packet.Timestamp;
+
+        var sp = new SequencedPacket
+        {
+            Ssrc = packet.Ssrc,
+            Payload = packet.Payload,
+            Metadata = packet.ExtensionData,
+            SequenceNumber = seq,
+            Timestamp = ts,
+        };
+
         // Check for duplicate
-        if (_buffer.ContainsKey(packet.SequenceNumber))
+        if (_buffer.ContainsKey(sp.SequenceNumber))
         {
             _packetsDuplicate++;
             return;
         }
 
-        // Calculate playout time
-        long timestampDiff = RtpPacket.TimestampDifference(packet.Timestamp, _baseTimestamp);
-
         // Add to buffer
-        _buffer[packet.SequenceNumber] = packet;
+        _buffer[sp.SequenceNumber] = sp;
 
         var ticksDiff = now - _baseTimeTicks;
+        var timestampDiff = sp.Timestamp - _baseTimestamp;
         MeasureJitter(ticksDiff, timestampDiff);
 
         // Adapt buffer size
@@ -102,7 +190,7 @@ public class RtpJitterBuffer
     // but apparently this is the closest we get since C# 9.
     public abstract record PacketsReadyResult;
     public record NoPackets : PacketsReadyResult;
-    public record PacketsReady(List<RtpPacket> Packets) : PacketsReadyResult;
+    public record PacketsReady(List<SequencedPacket> Packets) : PacketsReadyResult;
     public record WaitFor(long Ticks) : PacketsReadyResult;
 
 
@@ -119,7 +207,7 @@ public class RtpJitterBuffer
             (double)(elapsedTicks - bufferDelayTicks) /
                 Stopwatch.Frequency * OpenFreqRtcClient.SAMPLE_RATE);
 
-        List<RtpPacket> readies = [];
+        List<SequencedPacket> readies = [];
         while (_buffer.Count > 0)
         {
             var first = _buffer.First();
@@ -150,7 +238,15 @@ public class RtpJitterBuffer
             }
         }
         _packetsPlayed += readies.Count;
-        // TODO other stats aggregation
+        foreach (var p in readies)
+        {
+            if (_lastReturnedPacket is long last)
+            {
+                long gap = p.SequenceNumber - last - 1;
+                if (gap > 0) _packetsLost += (int)gap;
+            }
+            _lastReturnedPacket = p.SequenceNumber;
+        }
         return new PacketsReady(readies);
     }
         

--- a/OpenFreq.Common/RTPPacket.cs
+++ b/OpenFreq.Common/RTPPacket.cs
@@ -140,39 +140,6 @@ public class RtpPacket
 
         return data;
     }
-    
-           
-    /// <summary>
-    /// Calculate expected sequence number difference (handles wraparound)
-    /// </summary>
-    public static int SequenceDifference(ushort seq1, ushort seq2)
-    {
-        // Handle 16-bit wraparound
-        int diff = seq1 - seq2;
-            
-        if (diff < -32768)
-            diff += 65536;
-        else if (diff > 32768)
-            diff -= 65536;
-            
-        return diff;
-    }
-        
-    /// <summary>
-    /// Calculate timestamp difference (handles wraparound)
-    /// </summary>
-    public static long TimestampDifference(uint ts1, uint ts2)
-    {
-        // Handle 32-bit wraparound
-        long diff = (long)ts1 - (long)ts2;
-            
-        if (diff < -2147483648L)
-            diff += 4294967296L;
-        else if (diff > 2147483648L)
-            diff -= 4294967296L;
-            
-        return diff;
-    }
         
     public override string ToString()
     {

--- a/OpenFreq.Common/RtpSourceContext.cs
+++ b/OpenFreq.Common/RtpSourceContext.cs
@@ -18,7 +18,7 @@ public sealed class RtpSourceContext : IDisposable
     public OpusDecoder OpusDecoder { get; }
     
     // Loss detection state
-    public ushort LastSequenceReceived { get; set; }
+    public long LastSequenceReceived { get; set; }
     public bool FirstPacketReceived { get; set; }
     
     // Last valid metadata from this source, used to reconstruct concealment packets

--- a/OpenFreq.Common/RtpSourceContext.cs
+++ b/OpenFreq.Common/RtpSourceContext.cs
@@ -1,6 +1,10 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Threading.Channels;
 using Concentus.Structs;
 using Microsoft.Extensions.Logging;
+using static OpenFreq.Common.RtpAudioReceiver;
 
 namespace OpenFreq.Common;
 
@@ -13,35 +17,262 @@ namespace OpenFreq.Common;
 public sealed class RtpSourceContext : IDisposable
 {
     public uint Ssrc { get; }
-    
+
+    // TODO: This is a crummy encapsulation boundary:
+    // RTPJitterBufferPool fishes the jitter buffer out of this context,
+    // adds packets to it, then stuffs them back in for decode.
+    // (It was no better before, when RTPAudioReceiver just juggled
+    // the context's guts directly.)
+    //
+    // Split these out better?
     public RtpJitterBuffer JitterBuffer { get; }
-    public OpusDecoder OpusDecoder { get; }
+    /// <summary>
+    /// Write to this channel to feed packets from the jitter buffer
+    /// into the decoder task.
+    /// </summary>
+    public ChannelWriter<SequencedPacket> ToDecode { get; }
+    /// <summary>
+    /// Used by the decoder task to feed the AudioReceived delegate.
+    /// </summary>
+    /// <remarks>
+    /// Under no circumstances should we close this;
+    /// it's chared by all contexts.
+    /// </remarks>
+    private ChannelWriter<AudioReceivedEventArgs> ToPlay { get; }
+    private OpusDecoder? OpusDecoder { get; }
+    private Task DecoderTask { get; }
     
     // Loss detection state
-    public long LastSequenceReceived { get; set; }
-    public bool FirstPacketReceived { get; set; }
+    private long LastSequenceReceived { get; set; }
+    private bool FirstPacketReceived { get; set; }
     
     // Last valid metadata from this source, used to reconstruct concealment packets
-    public AudioPacketMetadata? LastValidMetadata { get; set; }
+    private AudioPacketMetadata? LastValidMetadata { get; set; }
     
     // Used by the pool to prune sources that have gone silent
     public long LastActivityTicks { get; set; }
 
-    public RtpSourceContext(uint ssrc, ILoggerFactory loggerFactory, bool opusEnabled, int initialBufferMs)
+    // Help I'm trapped in an abstract object factory. If you get this, send help.
+    private ILogger<RtpSourceContext> Logger { get; }
+
+    public RtpSourceContext(
+        uint ssrc,
+        ILoggerFactory loggerFactory,
+        CancellationToken ct,
+        ChannelWriter<AudioReceivedEventArgs> player,
+        bool opusEnabled,
+        int initialBufferMs)
     {
+        Logger = loggerFactory.CreateLogger<RtpSourceContext>();
         Ssrc = ssrc;
+
         LastActivityTicks = Stopwatch.GetTimestamp();
 
         JitterBuffer = new RtpJitterBuffer(loggerFactory.CreateLogger<RtpJitterBuffer>());
         JitterBuffer.SetTargetBufferSize(initialBufferMs);
 
-        #pragma warning disable CS0618 // Using the new factory method will not work on Linux
-        OpusDecoder = new OpusDecoder(OpenFreqRtcClient.SAMPLE_RATE, 1);
-        #pragma warning restore CS0618
+        if (opusEnabled)
+        {
+            #pragma warning disable CS0618 // Using the new factory method will not work on Linux
+            OpusDecoder = new OpusDecoder(OpenFreqRtcClient.SAMPLE_RATE, 1);
+#pragma warning restore CS0618
+        }
+
+        // Wire up our task and off we go.
+        var decChan = Channel.CreateBounded<SequencedPacket>(new BoundedChannelOptions(128)
+        {
+            SingleReader = true,
+            FullMode = BoundedChannelFullMode.DropOldest
+        });
+        ToPlay = player;
+        ToDecode = decChan.Writer;
+        DecoderTask = Task.Run(() => DecodeLoop(ct, decChan.Reader));
+    }
+
+    private async Task DecodeLoop(CancellationToken ct, ChannelReader<SequencedPacket> chan)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            try
+            {
+                var p = await chan.ReadAsync(ct);
+
+                // Loss detection and concealment — per-source sequence
+                if (FirstPacketReceived)
+                {
+                    long expectedSeq = LastSequenceReceived + 1;
+
+                    if (p.SequenceNumber != expectedSeq)
+                    {
+                        long gap = p.SequenceNumber - expectedSeq;
+
+                        if (gap > 0 && gap < 100)
+                        {
+                            Logger.LogDebug(
+                                "SSRC={Ssrc:X8}: {Gap} lost packet(s) (seq {Start} to {End}), generating concealment",
+                                Ssrc, gap, expectedSeq, p.SequenceNumber - 1);
+
+                            for (long i = 0; i < gap; i++)
+                            {
+                                ushort lostSeq = (ushort)(expectedSeq + i);
+                                // Only the last lost packet can use FEC (next packet carries FEC for it)
+                                await GenerateConcealmentAudio(ct, lostSeq, i == gap - 1 ? p : null);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    FirstPacketReceived = true;
+                }
+
+                LastSequenceReceived = p.SequenceNumber;
+                await ProcessReadyPacket(ct, p);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (ChannelClosedException)
+            {
+                break;
+            }
+        }
+    }
+
+        /// <summary>
+    /// Process a packet that is ready for playout, using the source's own Opus decoder.
+    /// </summary>
+    private async Task ProcessReadyPacket(CancellationToken ct, SequencedPacket packet)
+    {
+        if (packet.Metadata is not { Length: > 0 })
+        {
+            Logger.LogWarning("SSRC={Ssrc:X8}: missing RTP header extension metadata", Ssrc);
+            return;
+        }
+
+        var metadataJson = System.Text.Encoding.UTF8.GetString(packet.Metadata).TrimEnd('\0');
+        var metadata = JsonSerializer.Deserialize(metadataJson, OpenFreqJsonContext.Default.AudioPacketMetadata);
+
+        if (metadata == null)
+        {
+            Logger.LogWarning("SSRC={Ssrc:X8}: failed to parse metadata", Ssrc);
+            return;
+        }
+
+        LastValidMetadata = metadata;
+
+        Memory<short> decodedAudio;
+        if (OpusDecoder != null)
+        {
+            decodedAudio = DecodeOpus(packet.Payload, decodeFec: false);
+            if (decodedAudio.Length == 0)
+                return;
+        }
+        else
+        {
+            var buf = new short[packet.Payload.Length / 2];
+            decodedAudio = new Memory<short>(buf);
+            packet.Payload.CopyTo(MemoryMarshal.AsBytes(decodedAudio.Span));
+        }
+
+        #if DEBUG
+        Logger.LogDebug($"Playing packet from {packet.Ssrc}: {packet.SequenceNumber}");
+        #endif
+            
+        await ToPlay.WriteAsync(new AudioReceivedEventArgs
+        {
+            AudioData = decodedAudio,
+            Metadata = metadata
+        }, ct);
+    }
+
+    /// <summary>
+    /// Generate FEC or PLC concealment audio for a lost packet within one source's context.
+    /// </summary>
+    private async Task GenerateConcealmentAudio(CancellationToken ct, ushort lostSequence, SequencedPacket? nextPacket)
+    {
+        Memory<short> concealmentAudio;
+
+        byte[] nextOpusData = nextPacket?.Payload ?? [];
+
+        Logger.LogDebug(
+            "SSRC={Ssrc:X8}: loss recovery for seq {LostSeq}: {Bytes} bytes",
+            Ssrc, lostSequence, nextOpusData.Length);
+
+        concealmentAudio = DecodeOpus(nextOpusData, decodeFec: nextPacket != null);
+
+        if (concealmentAudio.Length == 0)
+            return;
+
+        var frequencies = new List<FrequencyTransmission>();
+        if (LastValidMetadata?.Frequencies != null)
+        {
+            foreach (var freq in LastValidMetadata.Frequencies)
+            {
+                frequencies.Add(new FrequencyTransmission(
+                    khz: freq.Khz,
+                    txPowerWatts: freq.TxPowerWatts,
+                    ppm: freq.Ppm,
+                    position: freq.Position,
+                    velocity: freq.Velocity,
+                    in3d: freq.In3d,
+                    ambientNoiseType: freq.AmbientNoiseType
+                ));
+            }
+        }
+
+        var metadata = new AudioPacketMetadata
+        {
+            ClientId = LastValidMetadata?.ClientId ?? "Recovered",
+            Frequencies = frequencies
+        };
+
+        await ToPlay.WriteAsync(new AudioReceivedEventArgs
+        {
+            AudioData = concealmentAudio,
+            Metadata = metadata
+        }, ct);
+    }
+
+    /// <summary>
+    /// Decode Opus audio using the provided decoder instance (one per SSRC).
+    /// </summary>
+    private Memory<short> DecodeOpus(ReadOnlySpan<byte> opusData, bool decodeFec)
+    {
+        const int OPUS_FRAME_SAMPLES = 960; // 20ms at 48kHz (matches sender)
+
+        try
+        {
+            short[] pcmSamples = new short[OPUS_FRAME_SAMPLES];
+            var outSpan = new Memory<short>(pcmSamples);
+
+            int samplesDecoded;
+
+            // We're actually looking for the _previous_ packet,
+            // which can be FEC'd into the next in case it gets lost.
+            samplesDecoded = OpusDecoder.Decode(
+                opusData, outSpan.Span, OPUS_FRAME_SAMPLES, decodeFec);
+
+            if (samplesDecoded <= 0)
+            {
+                Logger.LogWarning("Opus decode failed for {ByteCount} bytes (decodeFec={DecodeFec})",
+                    opusData.Length, decodeFec);
+                return Memory<short>.Empty;
+            }
+            return outSpan[..samplesDecoded];
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Opus decode exception (decodeFec={DecodeFec})", decodeFec);
+            return Memory<short>.Empty;
+        }
     }
 
     public void Dispose()
     {
+        ToDecode.Complete();
+        DecoderTask.Wait();
         OpusDecoder?.Dispose();
     }
 }


### PR DESCRIPTION
- Don't decode on a fixed timer, run in a loop that wakes up whenever there's packets
- Fix rollover handling, algorithm borrowed from SRTP (RFC 3711)