### PR TITLE
Jitter buffer is the sole arbiter of "late"

### DIFF
--- a/OpenFreq.Common/RTPAudioReceiver.cs
+++ b/OpenFreq.Common/RTPAudioReceiver.cs
@@ -196,7 +196,7 @@ public class RtpAudioReceiver : IDisposable
                                 context.ToDecode.TryWrite(new SequencedPacket
                                 {
                                     Ssrc = context.Ssrc,
-                                    SequenceNumber = 0, // source context uses its own LastSequenceReceived+1
+                                    SequenceNumber = 0,
                                     Timestamp = 0,
                                     Payload = cn.FecPayload ?? [],
                                     Metadata = null,

--- a/OpenFreq.Common/RtpSourceContext.cs
+++ b/OpenFreq.Common/RtpSourceContext.cs
@@ -41,11 +41,7 @@ public sealed class RtpSourceContext : IDisposable
     private ChannelWriter<AudioReceivedEventArgs> ToPlay { get; }
     private OpusDecoder? OpusDecoder { get; }
     private Task DecoderTask { get; }
-    
-    // Loss detection state
-    private long LastSequenceReceived { get; set; }
-    private bool FirstPacketReceived { get; set; }
-    
+
     // Last valid metadata from this source, used to reconstruct concealment packets
     private AudioPacketMetadata? LastValidMetadata { get; set; }
     
@@ -102,44 +98,18 @@ public sealed class RtpSourceContext : IDisposable
                 // p.Payload is empty for burst-loss or first-frame loss -> use PLC.
                 if (p.IsConcealment)
                 {
-                    if (FirstPacketReceived && LastValidMetadata != null)
+                    if (LastValidMetadata != null)
                     {
-                        long lostSeq = LastSequenceReceived + 1;
                         // Wrap payload in a minimal packet so GenerateConcealmentAudio  can reach it via nextPacket?.Payload; null signals pure PLC.
                         SequencedPacket? fecPacket = p.Payload.Length > 0 ? p : null;
                         Logger.LogDebug(
-                            "SSRC={Ssrc:X8}: proactive {Mode} for seq {Seq}",
-                            Ssrc, fecPacket != null ? "FEC" : "PLC", lostSeq);
-                        await GenerateConcealmentAudio(ct, (ushort)lostSeq, fecPacket);
-                        LastSequenceReceived = lostSeq;
+                            "SSRC={Ssrc:X8}: proactive {Mode}",
+                            Ssrc, fecPacket != null ? "FEC" : "PLC");
+                        await GenerateConcealmentAudio(ct, fecPacket);
                     }
                     continue;
                 }
 
-                // Discard genuinely late packets
-                if (FirstPacketReceived && p.SequenceNumber <= LastSequenceReceived)
-                {
-                    Logger.LogWarning(
-                        "SSRC={Ssrc:X8}: discarding late packet seq={Seq} (last decoded={Last})",
-                        Ssrc, p.SequenceNumber, LastSequenceReceived);
-                    continue;
-                }
-
-                if (!FirstPacketReceived)
-                    FirstPacketReceived = true;
-
-                // Diagnostic: jitter buffer should have injected ConcealmentNeeded for  every missing slot - a gap here means it missed one
-                if (FirstPacketReceived && p.SequenceNumber != LastSequenceReceived + 1)
-                {
-                    long gap = p.SequenceNumber - LastSequenceReceived - 1;
-                    if (gap is > 0 and < 100)
-                        Logger.LogDebug(
-                            "SSRC={Ssrc:X8}: unexpected seq gap of {Gap} before seq {Seq} " +
-                            "(jitter-buffer miss — PLC was not generated for these slots)",
-                            Ssrc, gap, p.SequenceNumber);
-                }
-
-                LastSequenceReceived = p.SequenceNumber;
                 await ProcessReadyPacket(ct, p);
             }
             catch (OperationCanceledException) { break; }
@@ -202,15 +172,15 @@ public sealed class RtpSourceContext : IDisposable
     /// <summary>
     /// Generate FEC or PLC concealment audio for a lost packet within one source's context.
     /// </summary>
-    private async Task GenerateConcealmentAudio(CancellationToken ct, ushort lostSequence, SequencedPacket? nextPacket)
+    private async Task GenerateConcealmentAudio(CancellationToken ct, SequencedPacket? nextPacket)
     {
         Memory<short> concealmentAudio;
 
         byte[] nextOpusData = nextPacket?.Payload ?? [];
 
         Logger.LogDebug(
-            "SSRC={Ssrc:X8}: loss recovery for seq {LostSeq}: {Bytes} bytes",
-            Ssrc, lostSequence, nextOpusData.Length);
+            "SSRC={Ssrc:X8}: loss recovery: {Bytes} bytes",
+            Ssrc, nextOpusData.Length);
 
         concealmentAudio = DecodeOpus(nextOpusData, decodeFec: nextPacket != null);
 
@@ -218,8 +188,8 @@ public sealed class RtpSourceContext : IDisposable
         if (concealmentAudio.Length == 0 && nextPacket != null)
         {
             Logger.LogDebug(
-                "SSRC={Ssrc:X8}: FEC had no LBRR for seq {LostSeq}, falling back to PLC",
-                Ssrc, lostSequence);
+                "SSRC={Ssrc:X8}: FEC had no LBRR, falling back to PLC",
+                Ssrc);
             concealmentAudio = DecodeOpus([], decodeFec: false);
         }
 


### PR DESCRIPTION
Trying to detect "also late" in the decoder was causing us to drop the start of every new transmit.

Counts of interest from a log:
- 1046 × `"discarding late packet"` warnings
- 295 × `"Transmission gap detected"` info messages
- 0 × buffer underrun / explicit loss messages
- 14 unique SSRCs (some rejoined after the 5-minute prune timeout)

The discard warnings come in batches of exactly 3 consecutive sequence numbers, where the last seq in each batch equals `last decoded`:

```
discarding late packet seq=4 (last decoded=6)
discarding late packet seq=5 (last decoded=6)
discarding late packet seq=6 (last decoded=6)
```

Distribution of `last_decoded - seq` confirms it:

| diff | count |
|------|-------|
| 0    | 357   |
| 1    | 334   |
| 2    | 335   |
| 3+   | ~20   |

That's 1,005/1,046 explained by "always three sequential packets, ending at exactly `last decoded`." `MAX_BLIND_CONCEAL_FRAMES = 3` in `RTPJitterbuffer.cs:82`.

Consider the sequence:

1. User finishes a talkspurt — last real packet is seq=N. `RtpSourceContext.LastSequenceReceived = N`.
2. Jitter buffer playout clock keeps ticking. Next slot has no packet, no later packet has been received → `provenGap = false`, `cap = MAX_BLIND_CONCEAL_FRAMES = 3` (`RTPJitterbuffer.cs:341`).
3. Jitter buffer fires 3 `ConcealmentNeeded` sentinels into the decode channel, one per 20ms slot.
4. Each sentinel hits `RtpSourceContext.DecodeLoop` which **blindly increments `LastSequenceReceived`** (`RtpSourceContext.cs:114`). After 3 frames, `LastSequenceReceived = N + 3`.
5. The cursor is dropped (`_lastReleasedPt = null`).
6. User presses PTT again. Sender's `sequence` counter is a local in `SendThreadProc` — it just continues. First real packet is seq=N+1.
7. Jitter buffer accepts seq=N+1, N+2, N+3 (no cursor, no time-based discard).
8. Decoder's late check `p.SequenceNumber <= LastSequenceReceived` (`RtpSourceContext.cs:120`) **drops all three**. User is only heard starting at seq=N+4.