### PR TITLE
proper cleanup of websocket on auth fail

### DIFF
--- a/OpenFreq.Common/OpenFreqRtcClient.cs
+++ b/OpenFreq.Common/OpenFreqRtcClient.cs
@@ -149,7 +149,9 @@ public class OpenFreqRtcClient : IDisposable
         catch (Exception ex)
         {
             IsConnected = false;
-            IsConnected = false;
+            CleanupRtp();
+            if (_webSocket?.State == WebSocketState.Open)
+                await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Connection failed", CancellationToken.None);
             OnConnectionStateChanged(ConnectionState.Disconnected);
             OnError($"Connection failed: {ex.Message}");
             throw;


### PR DESCRIPTION
properly closes the websocket on any failure of the auth process (including the initial RTP packet)