### PR TITLE
ensures IVC mutex owned by OpenFreq process

### DIFF
--- a/OpenFreq.Client/Services/FalconRadioSharedMemoryService.cs
+++ b/OpenFreq.Client/Services/FalconRadioSharedMemoryService.cs
@@ -28,6 +28,10 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
     private Task? _rcsPollingTask;
     private CancellationTokenSource? _cts;
 
+    // Retry loop that takes over the mutex once a conflicting client releases it
+    private CancellationTokenSource? _conflictRetryCts;
+    private Task? _conflictRetryTask;
+
     // RCS (Status) - we CREATE this
     private IntPtr _hRcsMemory = IntPtr.Zero;
     private IntPtr _lpRcsBaseAddress = IntPtr.Zero;
@@ -60,6 +64,8 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
     public event EventHandler<RadioPowerChangedEventArgs>? PowerChanged;
     public event EventHandler<ConnectionParametersChangedEventArgs>? ConnectionParametersChanged;
     public event EventHandler<LogbookNameChangedEventArgs>? LogbookNameChanged;
+    public event EventHandler? RadioClientConflict;
+    public event EventHandler? RadioClientConflictResolved;
 
     public FalconRadioSharedMemoryService(ILogger<FalconRadioSharedMemoryService> logger)
     {
@@ -85,7 +91,9 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
         }
     }
 
-    public bool IsOwner => _hMutex != IntPtr.Zero;
+    // Latched so the UI can surface the conflict even if Start() ran (and fired RadioClientConflict)
+    // before the view model subscribed — e.g. during startup config load.
+    public bool HasConflict { get; private set; }
 
     public string? LogbookName
     {
@@ -176,6 +184,27 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
 
     public void Start()
     {
+        if (TryAcquireOwnership())
+        {
+            StartPollingLoops();
+            return;
+        }
+
+        // Another radio client (e.g. BMS IVC, or a second OpenFreq instance) already owns the mutex.
+        // We MUST own RCS to function — never fall back to read-only. Surface the IVC-active banner and
+        // keep retrying so we automatically take over the moment the other client releases the mutex.
+        _logger.LogError("Another radio client already owns the radio-client mutex. Retrying until released.");
+        HasConflict = true;
+        RadioClientConflict?.Invoke(this, EventArgs.Empty);
+        StartConflictRetryLoop();
+    }
+
+    /// <summary>
+    /// Attempts to grab the single-instance mutex and create the RCS shared memory.
+    /// Returns true on success (we own RCS), false if another client already owns the mutex.
+    /// </summary>
+    private bool TryAcquireOwnership()
+    {
         lock (_dataLock)
         {
             if (_state != ServiceState.Stopped)
@@ -193,33 +222,31 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
 
             if (error == ERROR_ALREADY_EXISTS)
             {
-                // Another radio client is already running
-                _logger.LogWarning("Another radio client is already active. This instance will run in READ-ONLY mode.");
-
-                // Clean up the mutex handle we got
+                // Clean up the mutex handle we got (we don't own it)
                 if (_hMutex != IntPtr.Zero)
                 {
                     Win32RadioMemory.CloseHandle(_hMutex);
                     _hMutex = IntPtr.Zero;
                 }
 
-                // Skip RCS creation - we won't write status
-                ChangeState(ServiceState.RcsCreated);
+                return false;
             }
-            else
+
+            _logger.LogInformation("Mutex acquired — RCS owner");
+            // We're the first/only instance - create RCS normally
+            if (!CreateRcsSharedMemory())
             {
-                _logger.LogInformation("Mutex acquired — RCS owner");
-                // We're the first/only instance - create RCS normally
-                if (!CreateRcsSharedMemory())
-                {
-                    CleanupResources();
-                    throw new InvalidOperationException("Failed to create RCS shared memory");
-                }
-
-                ChangeState(ServiceState.RcsCreated);
+                CleanupResources();
+                throw new InvalidOperationException("Failed to create RCS shared memory");
             }
-        }
 
+            ChangeState(ServiceState.RcsCreated);
+            return true;
+        }
+    }
+
+    private void StartPollingLoops()
+    {
         _cts = new CancellationTokenSource();
 
         var rccInterval = TimeSpan.FromSeconds(1.0 / _pollingFrequencyHz);
@@ -233,14 +260,52 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
         _logger.LogInformation("Started");
     }
 
+    /// <summary>
+    /// Polls for the mutex once per second while another client holds it. As soon as we acquire it,
+    /// finishes startup and raises <see cref="RadioClientConflictResolved"/> so the UI clears the banner.
+    /// </summary>
+    private void StartConflictRetryLoop()
+    {
+        _conflictRetryCts = new CancellationTokenSource();
+        var token = _conflictRetryCts.Token;
+
+        _conflictRetryTask = Task.Run(async () =>
+        {
+            using var timer = new PeriodicTimer(TimeSpan.FromSeconds(1));
+            try
+            {
+                while (await timer.WaitForNextTickAsync(token))
+                {
+                    if (!TryAcquireOwnership()) continue;
+
+                    HasConflict = false;
+                    StartPollingLoops();
+                    _logger.LogInformation("Acquired radio-client mutex after the conflict cleared");
+                    RadioClientConflictResolved?.Invoke(this, EventArgs.Empty);
+                    return;
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancelled by Stop()
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error while retrying radio-client mutex acquisition");
+            }
+        }, token);
+    }
+
     public void Stop()
     {
+        _conflictRetryCts?.Cancel();
         _cts?.Cancel();
         _rccTimer?.Dispose();
         _rcsTimer?.Dispose();
 
         try
         {
+            _conflictRetryTask?.Wait(TimeSpan.FromSeconds(2));
             _rccPollingTask?.Wait(TimeSpan.FromSeconds(5));
             _rcsPollingTask?.Wait(TimeSpan.FromSeconds(5));
         }
@@ -248,6 +313,10 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
         {
             // dont care
         }
+
+        _conflictRetryCts?.Dispose();
+        _conflictRetryCts = null;
+        HasConflict = false;
 
         CleanupResources();
 
@@ -690,7 +759,7 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
 {
     public ServiceState State { get; }
     public double PollingFrequencyHz { get; set; }
-    public bool IsOwner => false;
+    public bool HasConflict => false;
     public string? LogbookName { get; }
     public RadioChannel? GetRadioChannel(RadioType radioType)
     {
@@ -731,6 +800,8 @@ public class FalconRadioSharedMemoryService : IFalconRadioSharedMemoryService
     public event EventHandler<RadioPowerChangedEventArgs>? PowerChanged;
     public event EventHandler<ConnectionParametersChangedEventArgs>? ConnectionParametersChanged;
     public event EventHandler<LogbookNameChangedEventArgs>? LogbookNameChanged;
+    public event EventHandler? RadioClientConflict;
+    public event EventHandler? RadioClientConflictResolved;
 #pragma warning restore CS0067
 
     public void Start()

--- a/OpenFreq.Client/Services/FalconSharedMemoryService.cs
+++ b/OpenFreq.Client/Services/FalconSharedMemoryService.cs
@@ -21,7 +21,7 @@ namespace OpenFreq.Client.Services;
 public class FalconSharedMemoryService(ILogger<FalconSharedMemoryService> logger) : IFalconSharedMemoryService
 {
     private System.Diagnostics.Process? _bmsProcess;
-    
+
     // Shared memory area names
     private const string PRIMARY_SHARED_MEMORY = "FalconSharedMemoryArea";
     private const string STRING_SHARED_MEMORY = "FalconSharedMemoryAreaString";
@@ -33,11 +33,11 @@ public class FalconSharedMemoryService(ILogger<FalconSharedMemoryService> logger
     private const int OFFSET_X = 0; // float at byte 0
     private const int OFFSET_Y = 4; // float at byte 4
     private const int OFFSET_Z = 8; // float at byte 8
-    
+
     private const int OFFSET_X_DOT = 12; // float at byte 0
     private const int OFFSET_Y_DOT = 16; // float at byte 4
     private const int OFFSET_Z_DOT = 20; // float at byte 8
-    
+
     private const int OFFSET_HSIBITS = 232; // hsiBits (uint) at byte 232
 
     private ServiceState _state = ServiceState.Stopped;
@@ -84,7 +84,7 @@ public class FalconSharedMemoryService(ILogger<FalconSharedMemoryService> logger
                 return _position;
         }
     }
-    
+
     public FlightVelocity? Velocity
     {
         get
@@ -172,6 +172,8 @@ public class FalconSharedMemoryService(ILogger<FalconSharedMemoryService> logger
 
         lock (_dataLock)
         {
+            // Reset so the next Start() re-signals a false -> true transition
+            _wasFlying = false;
             ChangeState(ServiceState.Stopped);
         }
 
@@ -213,7 +215,7 @@ public class FalconSharedMemoryService(ILogger<FalconSharedMemoryService> logger
                         }
                         continue;
                     }
-                    
+
                     // Read data
                     if (!TryReadFlightData())
                     {
@@ -311,7 +313,7 @@ public class FalconSharedMemoryService(ILogger<FalconSharedMemoryService> logger
             return false;
         }
     }
-    
+
     private System.Diagnostics.Process? FindBmsProcess()
     {
         try
@@ -332,15 +334,15 @@ public class FalconSharedMemoryService(ILogger<FalconSharedMemoryService> logger
         {
             _logger.LogWarning(ex, "Failed to find BMS process");
         }
-    
+
         return null;
     }
-    
+
     private bool IsBmsProcessRunning()
     {
         if (_bmsProcess == null)
             return true; // Don't know, so assume it's running
-    
+
         try
         {
             // HasExited throws if process handle is invalid
@@ -398,11 +400,11 @@ public class FalconSharedMemoryService(ILogger<FalconSharedMemoryService> logger
 
             // For some reason, the BMS altitude is inverted
             float z = BitConverter.ToSingle(ReadBytes(_lpPrimaryBaseAddress, OFFSET_Z, 4), 0) * -1;
-            
+
             // Read the velocity
             float xDot = BitConverter.ToSingle(ReadBytes(_lpPrimaryBaseAddress, OFFSET_X_DOT, 4), 0);
             float yDot = BitConverter.ToSingle(ReadBytes(_lpPrimaryBaseAddress, OFFSET_Y_DOT, 4), 0);
-            
+
             // Inverted
             float zDot = BitConverter.ToSingle(ReadBytes(_lpPrimaryBaseAddress, OFFSET_Z_DOT, 4), 0) * -1;
 

--- a/OpenFreq.Client/Services/Interfaces/IFalconRadioSharedMemoryService.cs
+++ b/OpenFreq.Client/Services/Interfaces/IFalconRadioSharedMemoryService.cs
@@ -11,11 +11,8 @@ public interface IFalconRadioSharedMemoryService : IDisposable, ILifecycleServic
     ServiceState State { get; }
     double PollingFrequencyHz { get; set; }
 
-    /// <summary>
-    /// True when this instance owns the radio-client mutex and has created the RCS shared memory.
-    /// False in read-only mode (another client, e.g. IVC, grabbed the mutex first).
-    /// </summary>
-    bool IsOwner { get; }
+    // True while another client (IVC or another OpenFreq instance) owns the radio mutex, so we don't.
+    bool HasConflict { get; }
 
     // Current data (thread-safe)
     string? LogbookName { get; }
@@ -43,6 +40,10 @@ public interface IFalconRadioSharedMemoryService : IDisposable, ILifecycleServic
 
     // Logbook name change (mPlayerMap[0].LogBookName — populated once in-game)
     event EventHandler<LogbookNameChangedEventArgs>? LogbookNameChanged;
+
+    // Raised when another radio client owns the mutex on Start()
+    event EventHandler? RadioClientConflict;
+    event EventHandler? RadioClientConflictResolved;
 
     // Constant
     public const int BmsRadioOffFrequency = 9999;

--- a/OpenFreq.Client/Services/OpenFreqService.cs
+++ b/OpenFreq.Client/Services/OpenFreqService.cs
@@ -842,6 +842,7 @@ public class OpenFreqService : IOpenFreqService
         _tunedSlots.TryGetValue((frequencyKhz, slotId), out var tunedFrequencyData);
         if (tunedFrequencyData == null)
         {
+            _logger.LogWarning("No frequency data found, assuming own position of (0,0,0)");
             return null;
         }
 
@@ -856,10 +857,8 @@ public class OpenFreqService : IOpenFreqService
 
             case RadioStationData.RadioStationType.STATIONARY:
                 var position = tunedFrequencyData.RadioStation.Vector3;
-                return position == null
-                    ? null
-                    : new Vector3(position.X, position.Y,
-                        position.Z + tunedFrequencyData.RadioStation.Preset.AntennaElevation_m);
+                return new Vector3(position.X, position.Y,
+                    position.Z + tunedFrequencyData.RadioStation.Preset.AntennaElevation_m);
 
             case RadioStationData.RadioStationType.ACMI:
                 var acmiAircraftId = tunedFrequencyData.RadioStation.AcmiAircraftId;

--- a/OpenFreq.Client/ViewModels/MainWindowViewModel.cs
+++ b/OpenFreq.Client/ViewModels/MainWindowViewModel.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Net.Sockets;
 using System.Security.Authentication;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -354,10 +355,43 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
         _channelHandlers.Remove(ch);
     }
 
+    // Add grace period for failed Shmem polling - should never happen IRL but let's keep safe
+    private static readonly TimeSpan ShmemLossGracePeriod = TimeSpan.FromSeconds(2);
+    private CancellationTokenSource? _shmemLossGraceCts;
+
     private async void OnFalconSharedMemoryStateChanged(object? sender, ServiceStateChangedEventArgs e)
     {
-        if (e.OldState != ServiceState.Connected) return;
         if (Settings.ConnectionMode != IOpenFreqService.Mode.BMS) return;
+
+        // Recovered within the grace window — cancel the pending disconnect.
+        if (e.NewState == ServiceState.Connected)
+        {
+            _shmemLossGraceCts?.Cancel();
+            _shmemLossGraceCts = null;
+            return;
+        }
+
+        if (e.OldState != ServiceState.Connected) return;
+
+        _shmemLossGraceCts?.Cancel();
+        var cts = new CancellationTokenSource();
+        _shmemLossGraceCts = cts;
+        try
+        {
+            await Task.Delay(ShmemLossGracePeriod, cts.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            return; // shmem recovered — keep the WS connection
+        }
+        finally
+        {
+            if (ReferenceEquals(_shmemLossGraceCts, cts))
+                _shmemLossGraceCts = null;
+            cts.Dispose();
+        }
+
+        // Still not Connected after the grace window — treat as a real BMS exit.
         Settings.Is3dMode = _falconSharedMemoryService.IsFlying ?? false;
         await DisconnectAsync();
     }
@@ -742,6 +776,11 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
             PeerId = _openFreqService.PeerId ?? "";
             ClearError();
             SettingsDrawerOpened = false;
+
+            // Re-read live BMS flight state on connect to rule out stale local Is3dMode
+            if (Settings.ConnectionMode == IOpenFreqService.Mode.BMS &&
+                _falconSharedMemoryService.IsFlying is { } isFlying)
+                Dispatcher.UIThread.Post(() => Settings.Is3dMode = isFlying);
 
             if (Settings is { ModeIsGci: false, MinimizeOnConnect: true })
             {

--- a/OpenFreq.Client/ViewModels/MainWindowViewModel.cs
+++ b/OpenFreq.Client/ViewModels/MainWindowViewModel.cs
@@ -14,6 +14,7 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using DialogHostAvalonia;
 using FalconBmsDataService.Models;
 using FalconBmsDataService.Services;
 using FalconRadioService.Models;
@@ -163,6 +164,8 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
         _falconRadioSharedMemoryService.ConnectionParametersChanged +=
             FalconRadioSharedMemoryServiceOnConnectionParametersChanged;
         _falconRadioSharedMemoryService.LogbookNameChanged += OnLogbookNameChanged;
+        _falconRadioSharedMemoryService.RadioClientConflict += OnRadioClientConflict;
+        _falconRadioSharedMemoryService.RadioClientConflictResolved += OnRadioClientConflictResolved;
         _falconSharedMemoryService.FlyingStateChanged += OnFlyingStateChanged;
         _falconSharedMemoryService.StateChanged += OnFalconSharedMemoryStateChanged;
         _falconSharedMemoryService.AircraftInfoChanged += OnAircraftInfoChanged;
@@ -182,6 +185,10 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
         _ = LoadConfigurationAsync();
 
         _openFreqService.SetOwnPositionMode(Settings.ConnectionMode);
+
+        // A mutex conflict may already be in place so check explicitly.
+        if (_falconRadioSharedMemoryService.HasConflict)
+            Dispatcher.UIThread.Post(() => _ = ShowIvcActiveAsync(), DispatcherPriority.Loaded);
     }
 
     private void OnAircraftInfoChanged(object? sender, AircraftInfoChangedEventArgs e)
@@ -361,38 +368,50 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
         {
             await Dispatcher.UIThread.InvokeAsync(async () =>
             {
-                IvcWarning = ivcStatusChangedEventArgs.IsRunning;
-
-                if (!IvcWarning)
+                if (!ivcStatusChangedEventArgs.IsRunning)
                 {
-                    // IVC died — take over mutex and RCS if we were in read-only mode
-                    if (Settings.ConnectionMode == IOpenFreqService.Mode.BMS &&
-                        !_falconRadioSharedMemoryService.IsOwner)
-                    {
-                        _ = Task.Run(() =>
-                        {
-                            try
-                            {
-                                _falconRadioSharedMemoryService.Stop();
-                                _falconRadioSharedMemoryService.Start();
-                                _logger.LogInformation("Re-acquired radio client mutex after IVC exit");
-                            }
-                            catch (Exception ex)
-                            {
-                                _logger.LogError(ex, "Failed to restart FalconRadioSharedMemoryService after IVC exit");
-                            }
-                        });
-                    }
+                    // IVC process gone. The radio service's retry loop takes over the mutex on its own
+                    // and raises RadioClientConflictResolved, which clears the banner — but clear it here
+                    // too for the case where IVC was detected without ever holding the radio mutex.
+                    IvcWarning = false;
                     return;
                 }
 
-                await PromptKillIvcAsync();
+                await ShowIvcActiveAsync();
             });
         }
         catch (Exception e)
         {
             _logger.LogError("{ToString}", e.ToString());
         }
+    }
+
+    private void OnRadioClientConflict(object? sender, EventArgs e)
+    {
+        _logger.LogWarning("Radio client mutex conflict");
+        Dispatcher.UIThread.Post(() => _ = ShowIvcActiveAsync());
+    }
+
+    private void OnRadioClientConflictResolved(object? sender, EventArgs e)
+    {
+        _logger.LogInformation("Radio client conflict resolved");
+        Dispatcher.UIThread.Post(() =>
+        {
+            IvcWarning = false;
+
+            // Dismiss the kill-IVC prompt if it's still open — the conflict is gone.
+            if (_killIvcDialogOpen && DialogHost.IsDialogOpen("MainDialogHost"))
+                DialogHost.Close("MainDialogHost", false);
+        });
+    }
+
+    private bool _killIvcDialogOpen;
+
+    private async Task ShowIvcActiveAsync()
+    {
+        if (IvcWarning) return;
+        IvcWarning = true;
+        await PromptKillIvcAsync();
     }
 
     [RelayCommand]
@@ -403,14 +422,26 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
 
     private async Task PromptKillIvcAsync()
     {
-        if (!await ConfirmationDialogService.ShowAsync(
-                title: "IVC Client detected",
-                message: "The BMS IVC Client seems to be running.\n" +
-                         "OpenFreq will not work in BMS mode.\n" +
-                         "\n" +
-                         "Kill the IVC process?",
+        bool confirmed;
+        _killIvcDialogOpen = true;
+        try
+        {
+            confirmed = await ConfirmationDialogService.ShowAsync(
+                title: "Radio client conflict",
+                message: "Another radio client owns the radio shared memory.\n\n" +
+                         "This is usually the Falcon BMS IVC Client, but it can also be another OpenFreq instance. OpenFreq will not work in BMS mode until it is closed." +
+                         "\n\n" +
+                         "Kill the IVC process? (Close any other OpenFreq instance manually)",
                 cancelText: "Cancel",
-                confirmText: "Kill IVC")) return;
+                confirmText: "Kill IVC");
+        }
+        finally
+        {
+            _killIvcDialogOpen = false;
+        }
+
+        // Conflict cleared itself (other client closed) while the prompt was open, or user cancelled.
+        if (!confirmed) return;
 
         // Disconnect from any server first, then ensure BMS mode is active
         if (_openFreqService.IsConnected)
@@ -534,6 +565,10 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
         OnPropertyChanged(nameof(AppBarColorZone));
     }
 
+    private bool IsBmsConflictBlocking =>
+        Settings.ConnectionMode == IOpenFreqService.Mode.BMS &&
+        (_falconRadioSharedMemoryService.HasConflict || IvcWarning);
+
     [RelayCommand]
     private async Task ConnectAsync()
     {
@@ -542,6 +577,14 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
             // Gracefully handle if already connected
             if (_openFreqService.IsConnected)
             {
+                return;
+            }
+
+            // Block BMS connection while another radio client owns the radio shared memory.
+            if (IsBmsConflictBlocking)
+            {
+                ShowError("Another radio client (Falcon BMS IVC or another OpenFreq instance) owns the " +
+                          "radio shared memory. Close it before connecting in BMS mode.");
                 return;
             }
 
@@ -600,6 +643,8 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
     {
         if (_openFreqService.IsConnected) return;
         if (string.IsNullOrWhiteSpace(Settings.OpenFreqServerAddress)) return;
+        // Never join BMS while another radio client owns the radio shared memory.
+        if (IsBmsConflictBlocking) return;
 
         await _openFreqService.Initialize(Settings.GetSettings(),
             _audioService.GetRecordingBassIndex(Settings.RecordingDeviceIndex),
@@ -1024,6 +1069,8 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
         _falconRadioSharedMemoryService.ConnectionParametersChanged -=
             FalconRadioSharedMemoryServiceOnConnectionParametersChanged;
         _falconRadioSharedMemoryService.LogbookNameChanged -= OnLogbookNameChanged;
+        _falconRadioSharedMemoryService.RadioClientConflict -= OnRadioClientConflict;
+        _falconRadioSharedMemoryService.RadioClientConflictResolved -= OnRadioClientConflictResolved;
         _falconSharedMemoryService.FlyingStateChanged -= OnFlyingStateChanged;
         _falconSharedMemoryService.AircraftInfoChanged -= OnAircraftInfoChanged;
 

--- a/OpenFreq.Client/ViewModels/SettingsViewModel.cs
+++ b/OpenFreq.Client/ViewModels/SettingsViewModel.cs
@@ -137,12 +137,14 @@ public partial class SettingsViewModel : ViewModelBase, IDisposable
 
     partial void OnIs3dModeChanged(bool value)
     {
+        _logger.LogInformation("Game mode changed to {Mode}", value ? "In-game" : "Lobby");
         _openFreqService.Apply3dAudioEffects = value;
         _ = _openFreqService.NotifyModeAsync(value);
     }
 
     partial void OnConnectionModeChanged(IOpenFreqService.Mode value)
     {
+        _logger.LogInformation("Connection mode changed to {Mode}", value);
         switch (value)
         {
             case IOpenFreqService.Mode.BMS:
@@ -496,7 +498,7 @@ public partial class SettingsViewModel : ViewModelBase, IDisposable
     private Screen? FindScreenContainingPositionInWorkingArea(PixelPoint position)
     {
         return (
-            // All active screens, not just any screens overlapping the window! 
+            // All active screens, not just any screens overlapping the window!
             from screen in ((IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!)
                 .MainWindow!.Screens.All
             where screen.WorkingArea.Contains(position)

--- a/OpenFreq.Client/Views/MainWindow.axaml
+++ b/OpenFreq.Client/Views/MainWindow.axaml
@@ -727,7 +727,7 @@
                             Padding="12,10"
                             Background="Transparent"
                             Cursor="Hand"
-                            ToolTip.Tip="Click to kill IVC process">
+                            ToolTip.Tip="Click to kill the IVC process (close another OpenFreq instance manually)">
                         <Grid ColumnDefinitions="Auto,*">
                             <avalonia:MaterialIcon Grid.Column="0"
                                                   Kind="AlertCircleOutline"
@@ -738,12 +738,12 @@
                             <StackPanel Grid.Column="1"
                                         Margin="12,0,0,0"
                                         VerticalAlignment="Center">
-                                <TextBlock Text="IVC Conflict Detected"
+                                <TextBlock Text="Radio Client Conflict Detected"
                                            FontSize="13"
                                            FontWeight="SemiBold"
                                            Foreground="{DynamicResource MaterialBodyBrush}"
                                            Margin="0,0,0,2" />
-                                <TextBlock Text="Falcon BMS IVC must be closed to use OpenFreq in BMS mode."
+                                <TextBlock Text="Another radio client (Falcon BMS IVC or another OpenFreq instance) must be closed to use OpenFreq in BMS mode."
                                            FontSize="12"
                                            Foreground="{DynamicResource MaterialBodyBrush}"
                                            Opacity="0.65"


### PR DESCRIPTION
* Make sure we own IVC mutex
* Rephrase warning to cover both IVC or another OF instance running
* Retry owning the mutex
* Guard against connection when mutex conflict is there