### PR TITLE
Capture-side AGC tweaks, dynamic noise floor

### DIFF
--- a/OpenFreq.Client/OpenFreq.Client.csproj
+++ b/OpenFreq.Client/OpenFreq.Client.csproj
@@ -9,6 +9,8 @@
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <RootNamespace>openfreq-client</RootNamespace>
         <LangVersion>preview</LangVersion>
+        <!-- Lets us wrap native audio-callback buffers in a ReadOnlySpan without copying. -->
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(RuntimeIdentifier.StartsWith('win')) Or ($([MSBuild]::IsOSPlatform('Windows')) And '$(RuntimeIdentifier)' == '')">

--- a/OpenFreq.Client/Services/MicLevelNormalizer.cs
+++ b/OpenFreq.Client/Services/MicLevelNormalizer.cs
@@ -1,4 +1,5 @@
 using System;
+using OpenFreqAudio;
 
 namespace OpenFreqClient.Services;
 
@@ -9,29 +10,82 @@ namespace OpenFreqClient.Services;
 ///
 /// This is not to be confused by the AGC in the playback loop, it is only used on the TX side.
 /// Survives multiple talk-spurts, initial levelling needs about 1sec.
+///
+/// The noise gate is dynamic: while the operator is NOT transmitting the raw mic is fed to
+/// <see cref="UpdateNoiseFloor"/>, which tracks the room's noise floor. That value is then
+/// frozen and used as the gate threshold for the duration of the next talk-spurt, so we don't
+/// chase gain on background hiss.
 /// </summary>
-public sealed class MicLevelNormalizer(int sampleRate)
+public sealed class MicLevelNormalizer
 {
-    // Target average level
-    private const float TargetRms = 0.1f; // ~-20 dBFS
+    // Target average level (root mean squared).
+    // Human speach has a peak-to-average power level
+    // of about 12-18 dB, so we want to be about that many
+    // below full strength.
+    private const float TargetRms = 0.16f; // ~16 dBFS
 
-    // Gain range
-    private const float MinGain = 0.25f; // -12 dB
-    private const float MaxGain = 10.0f; // +20 dB
+    // 16-bit PCM full-scale magnitude; maps samples to/from float in ~[-1, 1].
+    private const float SampleScale = short.MaxValue;
 
-    // Noise floor
-    private const float NoiseGateRms = 0.005f; // ~-46 dBFS
+    // Noise gate. The threshold is tracked from the live mic while idle (UpdateNoiseFloor)
+    // then frozen during transmission. NoiseFloorSeedRms doubles as the startup seed so the
+    // first talk-spurt behaves like the old fixed gate before the estimate has warmed up.
+    private const float NoiseFloorSeedRms = 0.005f; // ~-46 dBFS
 
-    // Brick-wall ceiling just below full scale
-    private const float LimitCeiling = 0.97f; // ~-0.26 dBFS
+    // RMS low-pass (it's a mean, after all)
+    private const float LevelTau = 0.1f / 3f; // ~33ms, 95% in 100ms
 
-    // One-pole smoothing coefficients
-    private readonly float _rmsAlpha = 1.0f - MathF.Exp(-1.0f / (0.3f * sampleRate));  // RMS envelope, ~300 ms
-    private readonly float _gainAlpha = 1.0f - MathF.Exp(-1.0f / (1.0f * sampleRate)); // gain ramp, ~1 s
+    // We want our gain to duck loud inputs quickly,
+    // but rise again slowly so that when people push-to-think (boo!)
+    // it doesn't crank their volume up and clip once they actually speak.
+    private const float GainRiseTau = 1.0f;
+    private const float GainFallTau = 0.05f;
 
-    // Seed the envelope at the target so startup doesn't lurch
-    private float _envSq = TargetRms * TargetRms;        // smoothed mean-square of the signal
-    private float _gain = 1.0f;  // current applied gain
+    // Noise floor: slow to rise, quick to fall, so brief non-PTT transients (a cough, a
+    // door) don't ratchet the floor up while it still settles back down to true quiet.
+    private const float FloorAttackTau = 1.0f; // rising
+    private const float FloorDecayTau = 0.3f;  // falling
+
+    // TX-path smoothers
+    private readonly FirstOrderFilter _level; // Input RMS
+    private readonly AttackDecayFilter _gainRamp; // smoothed applied gain
+
+    // Idle-mic noise-floor follower. Holds the smoothed mean-square (so the asymmetric
+    // attack/decay compares like-for-like); sqrt of its tap is the floor RMS.
+    private readonly AttackDecayFilter _noiseFloor;
+
+    /// <summary>
+    /// Current noise-gate threshold (linear RMS). Recomputed from the live mic by
+    /// <see cref="UpdateNoiseFloor"/> while idle, then held constant during transmission.
+    /// </summary>
+    public float NoiseGateRms { get; private set; } = NoiseFloorSeedRms;
+
+    public MicLevelNormalizer(int sampleRate)
+    {
+        _level = FirstOrderFilter.MakeFirstOrderFilter(LevelTau, sampleRate, TargetRms * TargetRms);
+        _gainRamp = AttackDecayFilter.MakeAttackDecayFilter(GainRiseTau, GainFallTau, sampleRate);
+        _noiseFloor = AttackDecayFilter.MakeAttackDecayFilter(FloorAttackTau, FloorDecayTau, sampleRate);
+        // Seed in the mean-square domain so early PTT matches the old fixed gate.
+        _noiseFloor.D1 = NoiseFloorSeedRms * NoiseFloorSeedRms;
+    }
+
+    /// <summary>
+    /// Advances the noise-floor estimate from idle-mic samples. Call this with raw mic audio
+    /// whenever the operator is NOT transmitting; the resulting <see cref="NoiseGateRms"/> is
+    /// then frozen and used by <see cref="Process"/> during the next talk-spurt.
+    /// </summary>
+    public void UpdateNoiseFloor(ReadOnlySpan<short> samples)
+    {
+        foreach (short sample in samples)
+        {
+            float x = sample / SampleScale;
+            _noiseFloor.Apply(x * x);
+        }
+
+        float floorRms = MathF.Sqrt(_noiseFloor.D1);
+        // Add some margin to gate ~3dB above the measured noise floor.
+        NoiseGateRms = floorRms * 2.0f;
+    }
 
     /// <summary>
     /// Normalizes <paramref name="count"/> mono 16-bit PCM samples in place.
@@ -40,28 +94,22 @@ public sealed class MicLevelNormalizer(int sampleRate)
     {
         for (int i = 0; i < count; i++)
         {
-            float x = samples[i] / 32768f;
+            float x = samples[i] / SampleScale;
 
             // Track the smoothed RMS of the input.
-            _envSq += _rmsAlpha * (x * x - _envSq);
-            float rms = MathF.Sqrt(_envSq);
+            float rms = MathF.Sqrt(_level.Apply(x * x));
 
-            // Only chase a new gain target when there's actual speech present;
-            // otherwise hold the last gain so silence isn't pumped up.
+            // Only chase a new gain target when there's actual speech present (above the
+            // frozen noise gate); otherwise hold the last gain so silence isn't pumped up.
             float desiredGain = rms > NoiseGateRms
-                ? Math.Clamp(TargetRms / rms, MinGain, MaxGain)
-                : _gain;
+                ? TargetRms / rms
+                : _gainRamp.D1;
 
             // Slowly ramp toward the target
-            _gain += _gainAlpha * (desiredGain - _gain);
+            float gain = _gainRamp.Apply(desiredGain);
 
-            float y = x * _gain;
-
-            // Brick-wall limiter, we don't want any overshoots
-            if (y > LimitCeiling) y = LimitCeiling;
-            else if (y < -LimitCeiling) y = -LimitCeiling;
-
-            samples[i] = (short)(y * 32767f);
+            float y = Math.Clamp(x * gain, -1, 1);
+            samples[i] = (short)(y * SampleScale);
         }
     }
 }

--- a/OpenFreq.Client/Services/MicLevelNormalizer.cs
+++ b/OpenFreq.Client/Services/MicLevelNormalizer.cs
@@ -22,7 +22,7 @@ public sealed class MicLevelNormalizer
     // Human speach has a peak-to-average power level
     // of about 12-18 dB, so we want to be about that many
     // below full strength.
-    private const float TargetRms = 0.16f; // ~16 dBFS
+    private const float TargetRms = 0.1f; // ~20 dBFS
 
     // 16-bit PCM full-scale magnitude; maps samples to/from float in ~[-1, 1].
     private const float SampleScale = short.MaxValue;

--- a/OpenFreq.Client/Services/OpenFreqService.cs
+++ b/OpenFreq.Client/Services/OpenFreqService.cs
@@ -181,7 +181,17 @@ public class OpenFreqService : IOpenFreqService
         }
     }
 
-    public bool MicNormalizationEnabled { get; set; } = true;
+    public bool MicNormalizationEnabled
+    {
+        get;
+        set
+        {
+            field = value;
+            // Continuous capture (for noise-floor tracking) is tied to this toggle, so the
+            // mic stream needs to open/close when it flips while connected and idle.
+            UpdateMicCaptureState();
+        }
+    } = true;
 
     public double SidetoneVolume
     {
@@ -416,6 +426,10 @@ public class OpenFreqService : IOpenFreqService
 
         try
         {
+            // Stop continuous mic capture explicitly: client events are unsubscribed below
+            // before the disconnect, so the event-driven close path won't run here.
+            StopMicCapture();
+
             if (_playbackService != null)
             {
                 // Always stop recording before tearing streams down.
@@ -563,6 +577,9 @@ public class OpenFreqService : IOpenFreqService
         }
 
         _peerStreams.Clear();
+        // Close continuous capture now that we're disconnected (also closed via the connection
+        // event on unexpected drops, but be explicit on the graceful path).
+        StopMicCapture();
         OnStatusMessage("Disconnected from OpenFreq server");
         Status = IOpenFreqService.OpenFreqStatus.Disconnected;
     }
@@ -667,6 +684,9 @@ public class OpenFreqService : IOpenFreqService
             return;
         }
 
+        // Whether we're transitioning from idle → transmitting (i.e. first active TX).
+        bool wasIdle = _activeTransmissionsAndMutedFrequencies.IsEmpty;
+
         // Add to active transmissions (TX is per-frequency; only one TX per frequency at a time)
         _activeTransmissionsAndMutedFrequencies.TryAdd(frequencyKhz, mutedFrequencies);
         _activeTransmissionSlots[frequencyKhz] = slotId;
@@ -675,44 +695,22 @@ public class OpenFreqService : IOpenFreqService
         // Mute the noise
         //_playbackService.SetSquelchLevel(frequency, 1.0f);
 
-        // If this is the FIRST transmission, start recording
-        if (_recordHandle == 0)
+        // Make sure the mic stream is live. With normalization enabled it's usually already
+        // open for continuous noise-floor tracking; otherwise this opens it just for the
+        // duration of the transmission.
+        if (!StartMicCapture())
         {
-            //_playbackService.SetSquelchLevel(frequency, 0.01f);
-            // RecordInit: Errors.Already is fine — AudioService.Init may have already done it.
-            if (!Bass.RecordInit(RecordingDeviceIndex) && Bass.LastError != Errors.Already)
-            {
-                var initMsg = $"Failed to initialize recording device (BASS index {RecordingDeviceIndex}): {Bass.LastError}";
-                _logger.LogError("{Message}", initMsg);
-                AudioPlaybackErrorOccurred?.Invoke(this, initMsg);
-                _activeTransmissionsAndMutedFrequencies.Clear();
-                return;
-            }
+            // Couldn't open the mic — roll this transmission back so we don't TX silence.
+            _activeTransmissionsAndMutedFrequencies.TryRemove(frequencyKhz, out _);
+            _activeTransmissionSlots.TryRemove(frequencyKhz, out _);
+            return;
+        }
 
-            Bass.CurrentRecordingDevice = RecordingDeviceIndex;
-            _logger.LogDebug("RecordingDeviceIndex set to {RecordingDeviceIndex}", RecordingDeviceIndex);
-
-            _recordHandle = Bass.RecordStart(
-                OpenFreqRtcClient.SAMPLE_RATE,
-                1,
-                BassFlags.RecordPause,
-                Period: 2,
-                RecordProcedure);
-
-            if (_recordHandle == 0)
-            {
-                var startMsg = $"Failed to start recording on device (BASS index {RecordingDeviceIndex}): {Bass.LastError}";
-                _logger.LogError("{Message}", startMsg);
-                AudioPlaybackErrorOccurred?.Invoke(this, startMsg);
-                _activeTransmissionsAndMutedFrequencies.Clear();
-                return;
-            }
-
+        // On the idle → transmitting edge, mark the start time and arm sidetone monitoring.
+        if (wasIdle)
+        {
             _client.MarkTransmitStartTime();
             if (_playbackService != null) _playbackService.SidetoneEnabled = SidetoneEnabled;
-
-            if (!Bass.ChannelPlay(_recordHandle))
-                _logger.LogWarning("ChannelPlay on record handle returned false: {Error}", Bass.LastError);
         }
 
         await _client.StartTransmissionAsync(frequencyKhz, Apply3dAudioEffects);
@@ -734,25 +732,97 @@ public class OpenFreqService : IOpenFreqService
             _playbackService?.RemoveTransmittingFrequencies(mutedFrequencies);
         }
 
-        // If NO more transmissions, stop recording and sidetone
-        if (_activeTransmissionsAndMutedFrequencies.IsEmpty && _recordHandle != 0)
+        // If NO more transmissions, clear sidetone and re-evaluate capture: the mic stays open
+        // for continuous noise-floor tracking when normalization is enabled, otherwise it closes.
+        if (_activeTransmissionsAndMutedFrequencies.IsEmpty)
         {
-            if (!Bass.ChannelStop(_recordHandle))
-            {
-                _logger.LogWarning("ChannelStop on record handle {Handle} returned false: {Error}",
-                    _recordHandle, Bass.LastError);
-            }
-
-            _recordHandle = 0;
             if (_playbackService != null)
             {
                 _playbackService.SidetoneEnabled = SidetoneEnabled;
                 _playbackService.ClearSidetone();
             }
+
+            UpdateMicCaptureState();
         }
 
         await _client.StopTransmissionAsync(frequencyKhz, Apply3dAudioEffects);
         OnStatusMessage($"Stopped transmitting on {frequencyKhz / 1000d:F3} MHz");
+    }
+
+    /// <summary>
+    /// Whether the shared mic stream should currently be open. The mic is held open while
+    /// connected if either we're transmitting, or normalization is on (so the noise-floor
+    /// estimator can keep tracking the room between talk-spurts).
+    /// </summary>
+    private bool WantMicCapture =>
+        IsConnected && (MicNormalizationEnabled || !_activeTransmissionsAndMutedFrequencies.IsEmpty);
+
+    /// <summary>
+    /// Opens or closes the shared mic capture stream to match <see cref="WantMicCapture"/>.
+    /// Safe to call repeatedly — it's a no-op when already in the desired state.
+    /// </summary>
+    private void UpdateMicCaptureState()
+    {
+        if (WantMicCapture) StartMicCapture();
+        else StopMicCapture();
+    }
+
+    /// <summary>
+    /// Opens the shared microphone capture stream if it isn't already running. The same stream
+    /// feeds the noise-floor estimator while idle and the TX path while transmitting.
+    /// Returns true if a stream is running on return.
+    /// </summary>
+    private bool StartMicCapture()
+    {
+        if (_recordHandle != 0) return true;
+
+        // RecordInit: Errors.Already is fine — AudioService.Init may have already done it.
+        if (!Bass.RecordInit(RecordingDeviceIndex) && Bass.LastError != Errors.Already)
+        {
+            var initMsg = $"Failed to initialize recording device (BASS index {RecordingDeviceIndex}): {Bass.LastError}";
+            _logger.LogError("{Message}", initMsg);
+            AudioPlaybackErrorOccurred?.Invoke(this, initMsg);
+            return false;
+        }
+
+        Bass.CurrentRecordingDevice = RecordingDeviceIndex;
+        _logger.LogDebug("RecordingDeviceIndex set to {RecordingDeviceIndex}", RecordingDeviceIndex);
+
+        _recordHandle = Bass.RecordStart(
+            OpenFreqRtcClient.SAMPLE_RATE,
+            1,
+            BassFlags.RecordPause,
+            Period: 2,
+            RecordProcedure);
+
+        if (_recordHandle == 0)
+        {
+            var startMsg = $"Failed to start recording on device (BASS index {RecordingDeviceIndex}): {Bass.LastError}";
+            _logger.LogError("{Message}", startMsg);
+            AudioPlaybackErrorOccurred?.Invoke(this, startMsg);
+            return false;
+        }
+
+        if (!Bass.ChannelPlay(_recordHandle))
+            _logger.LogWarning("ChannelPlay on record handle returned false: {Error}", Bass.LastError);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Stops and frees the shared microphone capture stream if running. No-op when idle.
+    /// </summary>
+    private void StopMicCapture()
+    {
+        if (_recordHandle == 0) return;
+
+        if (!Bass.ChannelStop(_recordHandle))
+            _logger.LogWarning("ChannelStop on record handle {Handle} returned false: {Error}",
+                _recordHandle, Bass.LastError);
+        if (!Bass.StreamFree(_recordHandle))
+            _logger.LogWarning("StreamFree on record handle {Handle} returned false: {Error}",
+                _recordHandle, Bass.LastError);
+        _recordHandle = 0;
     }
 
     public async Task NotifyModeAsync(bool is3d)
@@ -862,12 +932,31 @@ public class OpenFreqService : IOpenFreqService
 
     private bool RecordProcedure(int handle, IntPtr buffer, int length, IntPtr user)
     {
-        // If not transmitting on any frequency, skip
-        if (_activeTransmissionsAndMutedFrequencies.Count == 0)
-            return true;
-
         try
         {
+            // While not transmitting we keep the mic open purely so the normalizer can track
+            // the room's noise floor. Feed those idle samples to the estimator and return —
+            // nothing is sent, monitored, or recorded until PTT is held. This also freezes the
+            // gate during transmission: the estimate only advances on this idle path.
+            if (_activeTransmissionsAndMutedFrequencies.Count == 0)
+            {
+                if (MicNormalizationEnabled)
+                {
+                    // Read directly from the input buffer;
+                    // we'll actually allocate a GC array and copy below
+                    // if we actually need to grab a copy for sending.
+                    ReadOnlySpan<short> samples;
+                    unsafe
+                    {
+                        samples = new ReadOnlySpan<short>((void*)buffer, length / sizeof(short));
+                    }
+
+                    _micNormalizer.UpdateNoiseFloor(samples);
+                }
+
+                return true;
+            }
+
             // Handle first packet - BASS accumulates audio during initialization
             // Calculate expected size for 20ms at 48kHz, mono, 16-bit
             // 48000 samples/sec ÷ 50 = 960 samples per 20ms
@@ -1081,49 +1170,11 @@ public class OpenFreqService : IOpenFreqService
     {
         if (_recordHandle == 0) return;
 
-        // Stop current capture
-        if (!Bass.ChannelStop(_recordHandle))
-            _logger.LogWarning("ChannelStop on record handle {Handle} returned false: {Error}",
-                _recordHandle, Bass.LastError);
-        if (!Bass.StreamFree(_recordHandle))
-            _logger.LogWarning("StreamFree on record handle {Handle} returned false: {Error}",
-                _recordHandle, Bass.LastError);
-        _recordHandle = 0;
-
-        // Init new device — Errors.Already is fine (AudioService.Init may have done it)
-        if (!Bass.RecordInit(deviceIndex) && Bass.LastError != Errors.Already)
-        {
-            var msg = $"Failed to initialize recording device (BASS index {deviceIndex}): {Bass.LastError}";
-            _logger.LogError("{Message}", msg);
-            AudioPlaybackErrorOccurred?.Invoke(this, msg);
-            return;
-        }
-
-        Bass.CurrentRecordingDevice = deviceIndex;
-
-        _recordHandle = Bass.RecordStart(
-            OpenFreqRtcClient.SAMPLE_RATE, 1,
-            BassFlags.RecordPause, Period: 2,
-            RecordProcedure);
-
-        if (_recordHandle == 0)
-        {
-            var msg = $"Failed to restart recording on device (BASS index {deviceIndex}): {Bass.LastError}";
-            _logger.LogError("{Message}", msg);
-            AudioPlaybackErrorOccurred?.Invoke(this, msg);
-            return;
-        }
-
-        if (!Bass.ChannelPlay(_recordHandle))
-        {
-            var msg = $"Failed to resume recording channel on device (BASS index {deviceIndex}): {Bass.LastError}";
-            _logger.LogError("{Message}", msg);
-            AudioPlaybackErrorOccurred?.Invoke(this, msg);
-        }
-        else
-        {
+        // RecordingDeviceIndex has already been updated to deviceIndex by the caller, so the
+        // shared helpers pick up the new device. Reopen on it.
+        StopMicCapture();
+        if (StartMicCapture())
             _logger.LogInformation("Recording restarted on BASS device {Index}", deviceIndex);
-        }
     }
 
     // Client event handlers
@@ -1143,6 +1194,9 @@ public class OpenFreqService : IOpenFreqService
             _tunedSlots.Clear();
             _activeTransmissionSlots.Clear();
         }
+
+        // Open continuous capture once connected (for noise-floor tracking) / close it on drop.
+        UpdateMicCaptureState();
 
         ConnectionStateChanged?.Invoke(this, e);
     }
@@ -1464,15 +1518,8 @@ public class OpenFreqService : IOpenFreqService
         _cleanupCts?.Cancel();
         _cleanupCts?.Dispose();
 
-        // Stop all transmissions and free recording handle
-        if (_recordHandle != 0)
-        {
-            if (!Bass.ChannelStop(_recordHandle))
-                _logger.LogWarning("ChannelStop on record handle during Dispose returned false: {Error}", Bass.LastError);
-            if (!Bass.StreamFree(_recordHandle))
-                _logger.LogWarning("StreamFree on record handle during Dispose returned false: {Error}", Bass.LastError);
-            _recordHandle = 0;
-        }
+        // Stop all transmissions and free the recording handle
+        StopMicCapture();
         _activeTransmissionsAndMutedFrequencies.Clear();
 
         _playbackService?.StopAll();


### PR DESCRIPTION
- NEW! IMPROVED! Measure the noise floor dynamically whenever the user *isn't* talking - not everyone has an oversized podcaster mic and perfectly silent room.

- Remove RX-side ALC; It's certainly not what actual radios do, it's just an affordance I added before Richi added capture-side mic normalization.

- In a similar vein, boost the modulation index to 0.95 (the docs I've found say this is pretty typical) since we'll already have headroom from the capture side.