### PR TITLE
Recording: Remove old hard cap on buffer size

### DIFF
--- a/OpenFreq.Client/Services/OpenFreqService.cs
+++ b/OpenFreq.Client/Services/OpenFreqService.cs
@@ -955,28 +955,6 @@ public class OpenFreqService : IOpenFreqService
                 return true;
             }
 
-            // Handle first packet - BASS accumulates audio during initialization
-            // Calculate expected size for 20ms at 48kHz, mono, 16-bit
-            // 48000 samples/sec ÷ 50 = 960 samples per 20ms
-            // 960 samples × 2 bytes/sample × 1 channel = 1920 bytes
-            int expectedBytes = (OpenFreqRtcClient.SAMPLE_RATE / 50) * 2;
-
-            // TODO: I dont think we need this anymore with the shorter dsp updates. Deactivated for now
-            expectedBytes = 10000;
-
-            if (length > expectedBytes)
-            {
-                _logger.LogWarning("Recording packet oversized: {Length} bytes, truncating to {ExpectedBytes}",
-                    length, expectedBytes);
-                // Option 1: Only use the LAST 20ms (most recent audio)
-                buffer = IntPtr.Add(buffer, length - expectedBytes);
-                length = expectedBytes;
-
-                // Option 2: Skip first packet entirely
-                //_isFirstPacket = false;
-                //return true;
-            }
-
             // Copy audio data once
             short[] audioData = new short[length / 2];
             Marshal.Copy(buffer, audioData, 0, audioData.Length);


### PR DESCRIPTION
This was put in place when everything downstream assumed 20ms chunks, but that's no longer the case.
If the "extra" samples arrive before their playout time in a receiver's jitter buffer, great! Less dropouts!

Also includes OFA fixes
https://github.com/UOAF/OpenFreqAudio/commit/81c83282c1377b2e049478a8f5463ab96f109b4d
https://github.com/UOAF/OpenFreqAudio/commit/8407c75d5b813218aa2d398485c6d4d3c6dcc01e