### PR TITLE
Update recording filename format to use UTC timestamp in OpenFreqServ…

### DIFF
--- a/OpenFreq.Client/Services/OpenFreqService.cs
+++ b/OpenFreq.Client/Services/OpenFreqService.cs
@@ -518,7 +518,7 @@ public class OpenFreqService : IOpenFreqService
                     ? Path.Combine(exeDir, "recordings")
                     : RecordingPath;
                 Directory.CreateDirectory(dir);
-                var file = Path.Combine(dir, $"OpenFreq_{DateTime.Now:yyyyMMdd_HHmmss}.ogg");
+                var file = Path.Combine(dir, $"OpenFreq_{DateTime.UtcNow:yyyyMMddTHHmmss}Z.ogg");
                 _playbackService.StartRecording(file);
                 if (!_playbackService.IsRecording) return; // start failed; error already surfaced
                 OnStatusMessage($"Recording to {file}");


### PR DESCRIPTION
This PR should ensure that recording filenames now embed a Tacview-compatible UTC timestamp so session audio can auto-sync with ACMI telemetry during debrief.

Before: OpenFreq_20260727_171530.ogg (local time, underscore separator)
After: OpenFreq_20260727T151530Z.ogg (YYYYMMDDTHHMMSSZ UTC stamp)

Encoding is unchanged (Ogg/Vorbis). Only the filename format in OpenFreqService.StartRecording() is updated.

Why
Tacview auto-synchronizes media with telemetry when the filename contains a UTC timestamp in the form YYYYMMDDTHHMMSSZ (e.g. 20191024T091500Z for 2019-10-24 09:15 UTC). A timestamp in the filename takes priority over embedded media metadata.

Citation: [Synchronized Audio/Video Playback — Tacview documentation](https://raia-software-inc.gitbook.io/tacview/features/tacview-standard/synchronized-audio-video-playback) (“Sync by Timestamp”).

Test
Start a file recording and confirm the path looks like OpenFreq_YYYYMMDDTHHMMSSZ.ogg (UTC)
Load an ACMI whose timeline overlaps that UTC start, add the .ogg as media, and confirm Tacview auto-aligns without manual scrubbing